### PR TITLE
draft - adding more benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,22 @@
+name: Benchmark (with Criterion)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo bench --verbose

--- a/benches/rsdd_benchmark.rs
+++ b/benches/rsdd_benchmark.rs
@@ -27,10 +27,10 @@ fn bench03_cnf_bdd() -> () {
     compile_bdd(black_box(cnf_str));
 }
 
-fn bench_c8_easier_cnf_bdd() -> () {
-    let cnf_str = String::from(include_str!("../cnf/c8-very-easy.cnf"));
-    compile_bdd(black_box(cnf_str));
-}
+// fn bench_c8_easier_cnf_bdd() -> () {
+//     let cnf_str = String::from(include_str!("../cnf/c8-very-easy.cnf"));
+//     compile_bdd(black_box(cnf_str));
+// }
 
 fn bench_bdd_full(c: &mut Criterion) {
     let mut group = c.benchmark_group("sample-bdd-full");
@@ -38,9 +38,94 @@ fn bench_bdd_full(c: &mut Criterion) {
     group.bench_function("bench-01", |b| b.iter(|| bench01_cnf_bdd()));
     group.bench_function("bench-02", |b| b.iter(|| bench02_cnf_bdd()));
     group.bench_function("bench-03", |b| b.iter(|| bench03_cnf_bdd()));
-    group.bench_function("bench-c8-very-easy", |b| b.iter(|| bench_c8_easier_cnf_bdd()));
+    // group.bench_function("bench-c8-very-easy", |b| b.iter(|| bench_c8_easier_cnf_bdd()));
     group.finish();
 }
 
-criterion_group!(benches, bench_bdd_full);
+fn bench01_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/bench-01.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn bench02_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/bench-02.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn bench03_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/bench-03.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn c8easier_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/c8-easier.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn c8veryeasy_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/c8-very-easy.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn c8_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/c8.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn count_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/count.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn s298_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/s298.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn s344_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/s344.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn s444_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/s444.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn s510_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/s510.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn s641_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/s641.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn unsat1_cnf_from_file() -> () {
+    let cnf_str = String::from(include_str!("../cnf/unsat-1.cnf"));
+    Cnf::from_file(black_box(cnf_str));
+}
+
+fn bench_cnf_from_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sample-cnf-from-file");
+    group.sampling_mode(SamplingMode::Flat);
+    group.bench_function("bench-01", |b| b.iter(|| bench01_cnf_from_file()));
+    group.bench_function("bench-02", |b| b.iter(|| bench02_cnf_from_file()));
+    group.bench_function("bench-03", |b| b.iter(|| bench03_cnf_from_file()));
+    group.bench_function("c8-easier", |b| b.iter(|| c8easier_cnf_from_file()));
+    group.bench_function("c8-very-easy", |b| b.iter(|| c8veryeasy_cnf_from_file()));
+    group.bench_function("c8", |b| b.iter(|| c8_cnf_from_file()));
+    group.bench_function("count", |b| b.iter(|| count_cnf_from_file()));
+    group.bench_function("s298", |b| b.iter(|| s298_cnf_from_file()));
+    group.bench_function("s344", |b| b.iter(|| s344_cnf_from_file()));
+    group.bench_function("s444", |b| b.iter(|| s444_cnf_from_file()));
+    group.bench_function("s510", |b| b.iter(|| s510_cnf_from_file()));
+    group.bench_function("s641", |b| b.iter(|| s641_cnf_from_file()));
+    group.bench_function("unsat-1", |b| b.iter(|| unsat1_cnf_from_file()));
+    group.finish();
+}
+
+
+criterion_group!(benches, bench_bdd_full, bench_cnf_from_file);
 criterion_main!(benches);

--- a/src/backing_store/sdd_table.rs
+++ b/src/backing_store/sdd_table.rs
@@ -32,7 +32,6 @@ pub struct SddTable {
 
 impl SddTable {
     pub fn new(vtree: &VTree) -> SddTable {
-        println!("making new table with vtree {:?}", vtree);
         let mut t = SddTable {
             tables: Vec::new(),
             sdd_to_bdd: HashMap::new(),
@@ -72,9 +71,6 @@ impl SddTable {
 
     /// Converts a SDD var label into its internal BDD var label; panics on failure
     pub fn sdd_to_bdd_label(&self, label: &VarLabel) -> &VarLabel {
-        if self.sdd_to_bdd.get(label).is_none() {
-            println!("not found {:?} in table {:?}", label, self.sdd_to_bdd)
-        };
         self.sdd_to_bdd.get(label).unwrap()
     }
 

--- a/src/repr/bdd_plan.rs
+++ b/src/repr/bdd_plan.rs
@@ -2,15 +2,51 @@
 
 use super::var_label::VarLabel;
 use serde::{Serialize, Deserialize};
+use egg::{*, rewrite as rw};
 
-#[derive(Serialize, Deserialize, Debug)]
-enum LogicalFormula {
-    Var(VarLabel),
-    True,
-    False,
-    And(Box<LogicalFormula>, Box<LogicalFormula>),
-    Or(Box<LogicalFormula>, Box<LogicalFormula>),
-    Iff(Box<LogicalFormula>, Box<LogicalFormula>),
-    Not(Box<LogicalFormula>),
+
+define_language! {
+    pub enum BddPlan {
+        "true" = True,
+        "false" = False,
+        "and" = And([Id; 2]),
+        "or" = Or([Id; 2]),
+        "not" = Not([Id; 1]),
+        Symbol(Symbol),
+    }
 }
 
+pub fn optimize(r: &RecExpr<BddPlan>) -> RecExpr<BddPlan> {
+    let rules: &[Rewrite<BddPlan, ()>] = &[
+        rw!("commute-and"; "(and ?x ?y)" => "(and ?y ?x)"),
+        rw!("commute-or"; "(or ?x ?y)" => "(or ?y ?x)"),
+
+        rw!("and-f"; "(and ?x false)" => "false"),
+        rw!("and-t"; "(and ?x true)" => "?x"),
+        rw!("or-f"; "(or ?x false)" => "?x"),
+        rw!("or-t"; "(or ?x true)" => "true"),
+
+
+        rw!("and-incon"; "(and ?x (not ?x))" => "false"),
+        rw!("and-con"; "(and ?x ?x)" => "?x"),
+
+        rw!("or-incon"; "(or ?x (not ?x))" => "true"),
+        rw!("or-con"; "(or ?x ?x))" => "?x"),
+
+        rw!("dist-and"; "(and ?a (or ?b ?c))" => "(or (and ?a ?b) (and ?a ?c))"),
+        
+    ];
+    // That's it! We can run equality saturation now.
+    let runner = Runner::default().with_expr(r).run(rules);
+
+    // Extractors can take a user-defined cost function,
+    // we'll use the egg-provided AstSize for now
+    let extractor = Extractor::new(&runner.egraph, AstSize);
+
+    // We want to extract the best expression represented in the
+    // same e-class as our initial expression, not from the whole e-graph.
+    // Luckily the runner stores the eclass Id where we put the initial expression.
+    let (best_cost, best_expr) = extractor.find_best(runner.roots[0]);
+
+    return best_expr;
+}


### PR DESCRIPTION
This is a draft PR to provide more fine-grained benchmarks for rsdd using criterion.

Two very small changes:

1. Adds a smaller unit of benchmarking, in this case for `Cnf::from_file` - applies it to all the files in the `cnf/` directory.
2. Adds an Action to run `cargo bench` on push (though this is probably not a good idea - see below)

Some thoughts I'll jot down:

## on what to unit benchmark

Admittedly I'm not familiar at all with the general codebase, so I'm not sure exactly what the most optimal things to benchmark are first; I chose `Cnf::from_file` since I know it works as intended (it's already used in `compile_bdd`). What should I be looking for? For example, should I be aiming to cover things file-by-file, focus on the core path of functions for a set of files, or something else?

## on CI and `Iai`

On running in CI: looking at the [tidbit on `Iai` in the Criterion documentation](https://bheisler.github.io/criterion.rs/book/iai/comparison.html)

> Pro: Iai can work reliably in noisy CI environments or even cloud CI providers like GitHub Actions or Travis-CI, where Criterion-rs cannot.

and

> For benchmarks that run in CI (especially if you're checking for performance regressions in pull requests on cloud CI) you should use Iai. 

Perhaps I should investigate [`Iai`](https://github.com/bheisler/iai) then, even though it's not actively developed as much? It also seems to deal with our problem of longer benchmarks - it's designed for one-shot profiling. 

On this note, I think the author of both (Brook Heisler) is imagining some complementary approach:

1. we test the core, small functions routinely with `criterion` on some server
2. we run a cron of our end-to-end system on a small set of examples with `Iai` on a cloud CI

Any thoughts? 