### PR TITLE
ci: new `rustfmt` workflow, run CI on mac and ubuntu

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,14 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: rustfmt
+
+on:
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: cargo fmt --all -- --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  lint:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  lint:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
+  build:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,14 @@ env:
 
 jobs:
   lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/benches/rsdd_benchmark.rs
+++ b/benches/rsdd_benchmark.rs
@@ -37,9 +37,7 @@ fn bench_bdd_full(c: &mut Criterion) {
     group.bench_function("bench-01", |b| b.iter(bench01_cnf_bdd));
     group.bench_function("bench-02", |b| b.iter(bench02_cnf_bdd));
     group.bench_function("bench-03", |b| b.iter(bench03_cnf_bdd));
-    group.bench_function("bench-c8-very-easy", |b| {
-        b.iter(bench_c8_easier_cnf_bdd)
-    });
+    group.bench_function("bench-c8-very-easy", |b| b.iter(bench_c8_easier_cnf_bdd));
     group.finish();
 }
 

--- a/bin/compare_canonicalize.rs
+++ b/bin/compare_canonicalize.rs
@@ -124,7 +124,7 @@ fn compile_sdd_benchmark(cnf: &Cnf, vtree: VTree, modified: bool) -> Duration {
     let start = Instant::now();
     compiler.from_cnf(cnf);
     // let r = compiler.from_cnf(&cnf);
-    
+
     // let sz = compiler.count_nodes(r);
 
     start.elapsed()

--- a/src/backing_store/robin_hood.rs
+++ b/src/backing_store/robin_hood.rs
@@ -82,7 +82,7 @@ fn propagate(v: &mut [HashTableElement], cap: usize, itm: HashTableElement, pos:
         } else {
             // place the element in the current spot, we're done
             v[pos] = searcher;
-            return ;
+            return;
         }
     }
 }
@@ -111,7 +111,7 @@ where
     /// reserve a robin-hood table capable of holding at least `sz` elements
     pub fn new(sz: usize) -> BackedRobinHoodTable<T> {
         let v: Vec<HashTableElement> = zero_vec(sz);
-        
+
         BackedRobinHoodTable {
             elem: Vec::with_capacity(sz as usize),
             tbl: v,

--- a/src/backing_store/sdd_table.rs
+++ b/src/backing_store/sdd_table.rs
@@ -43,8 +43,7 @@ impl SddTable {
                     let mut new_order = Vec::new();
                     let mut m: HashMap<VarLabel, VarLabel> = HashMap::new();
                     for (var_idx, v) in o.iter().enumerate() {
-                        t.sdd_to_bdd
-                            .insert(*v, VarLabel::new(var_idx as u64));
+                        t.sdd_to_bdd.insert(*v, VarLabel::new(var_idx as u64));
                         m.insert(VarLabel::new(var_idx as u64), *v);
                         new_order.push(VarLabel::new(var_idx as u64));
                     }

--- a/src/builder/bdd_builder.rs
+++ b/src/builder/bdd_builder.rs
@@ -161,9 +161,7 @@ impl BddManager {
     /// Clear the internal scratch space for a BddPtr
     fn clear_scratch(&mut self, ptr: BddPtr) {
         if ptr.is_const() {
-            
         } else if self.compute_table.get_scratch(ptr).is_none() {
-            
         } else {
             self.compute_table.set_scratch(ptr, None);
             self.clear_scratch(self.low(ptr));
@@ -405,7 +403,7 @@ impl BddManager {
         let var = self.var(lbl, true);
         let iff = self.iff(var, g);
         let a = self.and(iff, f);
-        
+
         self.exists(a, lbl)
     }
 
@@ -504,7 +502,6 @@ impl BddManager {
 
     /// if f then g else h
     pub fn ite(&mut self, f: BddPtr, g: BddPtr, h: BddPtr) -> BddPtr {
-        
         self.ite_helper(f, g, h)
     }
 

--- a/src/builder/cache/bdd_app.rs
+++ b/src/builder/cache/bdd_app.rs
@@ -46,7 +46,6 @@ pub struct BddApplyTable {
 
 impl BddApplyTable {
     pub fn new(num_vars: usize) -> BddApplyTable {
-        
         BddApplyTable {
             table: (0..num_vars).map(|_| Lru::new(INITIAL_CAPACITY)).collect(),
         }

--- a/src/builder/decision_nnf_builder.rs
+++ b/src/builder/decision_nnf_builder.rs
@@ -111,9 +111,7 @@ impl DecisionNNFBuilder {
     /// Clear the internal scratch space for a BddPtr
     fn clear_scratch(&mut self, ptr: BddPtr) {
         if ptr.is_const() {
-            
         } else if self.compute_table.get_scratch(ptr).is_none() {
-            
         } else {
             self.compute_table.set_scratch(ptr, None);
             self.clear_scratch(self.low(ptr));

--- a/src/builder/repr/builder_bdd.rs
+++ b/src/builder/repr/builder_bdd.rs
@@ -182,11 +182,7 @@ pub struct BddNode {
 
 impl BddNode {
     pub fn new(low: BddPtr, high: BddPtr, var: VarLabel) -> BddNode {
-        BddNode {
-            low,
-            high,
-            var,
-        }
+        BddNode { low, high, var }
     }
 }
 
@@ -199,11 +195,7 @@ pub enum Bdd {
 
 impl Bdd {
     pub fn new_node(low: BddPtr, high: BddPtr, var: VarLabel) -> Bdd {
-        let new_n = BddNode {
-            low,
-            high,
-            var,
-        };
+        let new_n = BddNode { low, high, var };
         Bdd::Node(new_n)
     }
 

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -111,8 +111,6 @@ impl<'a> SddManager {
             app_cache.push(Lru::new(8));
         }
 
-        
-
         SddManager {
             tbl: SddTable::new(&vtree),
             stats: SddStats::new(),
@@ -262,7 +260,6 @@ impl<'a> SddManager {
         // we have a fresh SDD pointer, uniqify it
         node.sort_by(|a, b| a.0.cmp(&b.0));
 
-        
         if node[0].1.is_compl() {
             for i in 0..node.len() {
                 node[i].1 = node[i].1.neg();
@@ -648,10 +645,7 @@ impl<'a> SddManager {
                         .nest(2),
                     );
                 }
-                let d = Doc::from(format!(
-                    "{}\\/",
-                    if ptr.is_compl() { "!" } else { "" }
-                ));
+                let d = Doc::from(format!("{}\\/", if ptr.is_compl() { "!" } else { "" }));
                 d.append(doc.nest(2))
             }
         }
@@ -806,11 +800,13 @@ impl<'a> SddManager {
 #[test]
 fn simple_equality() {
     let mut mgr = SddManager::new(even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
             VarLabel::new(3),
-            VarLabel::new(4)],
+            VarLabel::new(4),
+        ],
         2,
     ));
     let a = mgr.var(VarLabel::new(0), true);
@@ -824,11 +820,13 @@ fn simple_equality() {
 #[test]
 fn sdd_simple_cond() {
     let mut mgr = SddManager::new(even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
             VarLabel::new(3),
-            VarLabel::new(4)],
+            VarLabel::new(4),
+        ],
         2,
     ));
     let a = mgr.var(VarLabel::new(0), true);
@@ -847,11 +845,13 @@ fn sdd_simple_cond() {
 #[test]
 fn sdd_test_exist() {
     let mut man = SddManager::new(even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
             VarLabel::new(3),
-            VarLabel::new(4)],
+            VarLabel::new(4),
+        ],
         2,
     ));
     // 1 /\ 2 /\ 3
@@ -873,11 +873,13 @@ fn sdd_test_exist() {
 #[test]
 fn sdd_ite1() {
     let mut man = SddManager::new(even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
             VarLabel::new(3),
-            VarLabel::new(4)],
+            VarLabel::new(4),
+        ],
         2,
     ));
     let v1 = man.var(VarLabel::new(0), true);
@@ -895,11 +897,13 @@ fn sdd_ite1() {
 #[test]
 fn sdd_circuit1() {
     let mut man = SddManager::new(even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
             VarLabel::new(3),
-            VarLabel::new(4)],
+            VarLabel::new(4),
+        ],
         2,
     ));
     let x = man.var(VarLabel::new(0), false);
@@ -923,11 +927,13 @@ fn sdd_circuit1() {
 fn sdd_circuit2() {
     // same as circuit1, but with a different variable order
     let mut man = SddManager::new(even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
             VarLabel::new(3),
-            VarLabel::new(4)],
+            VarLabel::new(4),
+        ],
         2,
     ));
     let x = man.var(VarLabel::new(3), false);
@@ -952,10 +958,12 @@ fn sdd_wmc1() {
     // modeling the formula (x<=>fx) && (y<=>fy), with f weight of 0.5
 
     let vtree = even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
-            VarLabel::new(3)],
+            VarLabel::new(3),
+        ],
         2,
     );
     let mut man = SddManager::new(vtree.clone());
@@ -985,10 +993,12 @@ fn sdd_wmc1() {
 #[test]
 fn sdd_wmc2() {
     let vtree = even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
-            VarLabel::new(3)],
+            VarLabel::new(3),
+        ],
         2,
     );
     let mut man = SddManager::new(vtree.clone());
@@ -1025,10 +1035,12 @@ fn is_canonical_trivial() {
 #[test]
 fn not_compressed_or_trimmed_trivial() {
     let mut man = SddManager::new(even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
-            VarLabel::new(3)],
+            VarLabel::new(3),
+        ],
         2,
     ));
 
@@ -1055,10 +1067,12 @@ fn not_compressed_or_trimmed_trivial() {
 #[test]
 fn test_compression() {
     let mut man = SddManager::new(even_split(
-        &[VarLabel::new(0),
+        &[
+            VarLabel::new(0),
             VarLabel::new(1),
             VarLabel::new(2),
-            VarLabel::new(3)],
+            VarLabel::new(3),
+        ],
         2,
     ));
 

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -454,7 +454,7 @@ impl Cnf {
         let sum = clause.iter().fold(0, |acc, &lbl| {
             lbl_to_pos[lbl.get_label().value() as usize] + acc
         });
-        
+
         (sum as f64) / (clause.len() as f64)
     }
 
@@ -571,7 +571,8 @@ impl Cnf {
                         .filter(|outer| {
                             !(lit.get_label() == outer.get_label()
                                 && lit.get_polarity() != outer.get_polarity())
-                        }).copied()
+                        })
+                        .copied()
                         .collect();
                     Some(filtered)
                 }

--- a/src/repr/model.rs
+++ b/src/repr/model.rs
@@ -69,10 +69,10 @@ impl PartialModel {
 
     /// Produces an iterator of all the assigned literals
     pub fn assignment_iter<'a>(&'a self) -> impl Iterator<Item = Literal> + 'a {
-        self.assignments
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, x)| x.as_ref().map(|v| Literal::new(VarLabel::new_usize(idx), *v)))
+        self.assignments.iter().enumerate().filter_map(|(idx, x)| {
+            x.as_ref()
+                .map(|v| Literal::new(VarLabel::new_usize(idx), *v))
+        })
     }
 
     pub fn unassigned_vars<'a>(&'a self) -> impl Iterator<Item = VarLabel> + 'a {

--- a/src/repr/sat_solver.rs
+++ b/src/repr/sat_solver.rs
@@ -130,7 +130,7 @@ impl<'a> UnitPropagate<'a> {
         let n = self.state.len();
         let cur_state_i = self.state[n - 1].get_vec().iter();
         let prev_state_i = self.state[n - 2].get_vec().iter();
-        
+
         cur_state_i
             .zip(prev_state_i)
             .enumerate()
@@ -158,9 +158,7 @@ impl<'a> UnitPropagate<'a> {
         // if already assigned, check if consistent -- if not, return unsat
         match self.cur_state().get(new_assignment.get_label()) {
             None => (),
-            Some(v) => {
-                return new_assignment.get_polarity() == v
-            }
+            Some(v) => return new_assignment.get_polarity() == v,
         };
 
         // update the value of the decided variable in the partial model
@@ -232,7 +230,8 @@ impl<'a> UnitPropagate<'a> {
                 // num_remaining > 1, find a new literal to watch
                 // first, find a new literal to watch
                 let candidate_unwatched: LitIdx = remaining_lits
-                    .clone().next()
+                    .clone()
+                    .next()
                     .unwrap()
                     .get_label()
                     .value_usize();

--- a/src/util/btree.rs
+++ b/src/util/btree.rs
@@ -256,8 +256,7 @@ impl LeastCommonAncestor {
         tree: &BTree<N, L>,
         map: &HashMap<*const BTree<N, L>, usize>,
         v: &mut Vec<usize>,
-    )
-    where
+    ) where
         N: PartialEq + Eq + Clone,
         L: PartialEq + Eq + Clone,
     {


### PR DESCRIPTION
Short and sweet PR that:

- creates a new workflow that runs `cargo fmt`/`rustfmt` on all files on PR
- runs both the lint and CI workflows on ubutnu and macOS (new)
- embarrassingly didn't actually fix all `cargo fmt` errors in #26, so does that too

---

An alternate suggestion is to bundle these into one workflow, so it's faster (i.e., run the lint after the tests). Not sure if that affects our other future plans (ex making `cargo build` a mandatory pass to merge, but being ok with lint errors). Open to thoughts here!

My personal take, in my opinion, is we should make all of these required to merge:

- `cargo build` passes cleanly
- no lint errors
- all tests pass