### PR TITLE
Reduce warnings with `cargo fix && cargo fmt --all`

### DIFF
--- a/bin/one_shot_benchmark.rs
+++ b/bin/one_shot_benchmark.rs
@@ -4,17 +4,17 @@ extern crate rsdd;
 extern crate serde_json;
 
 use clap::Parser;
-use rsdd::repr::dtree::DTree;
-use std::fs;
 use rsdd::builder::cache::lru_app::BddApplyTable;
 use rsdd::repr::bdd::BddPtr;
 use rsdd::repr::cnf::Cnf;
 use rsdd::repr::ddnnf::DDNNFPtr;
+use rsdd::repr::dtree::DTree;
 use rsdd::repr::var_label::VarLabel;
 use rsdd::repr::var_order::VarOrder;
 use rsdd::repr::vtree::VTree;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::fs;
 use std::time::Instant;
 
 /// Test driver for one-shot benchmark
@@ -29,9 +29,8 @@ struct Args {
     #[clap(short, long, value_parser)]
     file: String,
 
-
     /// Mode to compile in
-    /// Options: 
+    /// Options:
     ///    bdd_topological
     ///    sdd_right_linear
     ///    sdd_topological_elim: compile in a topological elimination order
@@ -61,7 +60,7 @@ struct BenchmarkLog {
 
 struct BenchResult {
     num_recursive: usize,
-    size: usize
+    size: usize,
 }
 
 // TODO: resolve unused
@@ -72,7 +71,10 @@ fn compile_topdown_nnf(str: String, args: &Args) -> BenchResult {
     let order = VarOrder::linear_order(cnf.num_vars());
     // let order = cnf.force_order();
     let ddnnf = man.from_cnf_topdown(&order, &cnf);
-    BenchResult { num_recursive: 0, size: ddnnf.count_nodes() }
+    BenchResult {
+        num_recursive: 0,
+        size: ddnnf.count_nodes(),
+    }
 }
 
 fn compile_sdd_dtree(str: String, _args: &Args) -> BenchResult {
@@ -81,17 +83,24 @@ fn compile_sdd_dtree(str: String, _args: &Args) -> BenchResult {
     let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
     let mut man = SddManager::new(dtree.to_vtree().unwrap());
     let _sdd = man.from_cnf(&cnf);
-    BenchResult { num_recursive: man.get_stats().num_rec, size: _sdd.count_nodes() }
+    BenchResult {
+        num_recursive: man.get_stats().num_rec,
+        size: _sdd.count_nodes(),
+    }
 }
-
 
 fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
     use rsdd::builder::sdd_builder::*;
     let cnf = Cnf::from_file(str);
-    let o : Vec<VarLabel> = (0..cnf.num_vars()).map(|x| VarLabel::new(x as u64)).collect();
+    let o: Vec<VarLabel> = (0..cnf.num_vars())
+        .map(|x| VarLabel::new(x as u64))
+        .collect();
     let mut man = SddManager::new(VTree::right_linear(&o));
     let _sdd = man.from_cnf(&cnf);
-    BenchResult { num_recursive: man.get_stats().num_rec, size: _sdd.count_nodes() }
+    BenchResult {
+        num_recursive: man.get_stats().num_rec,
+        size: _sdd.count_nodes(),
+    }
 }
 
 // TODO: resolve unused
@@ -101,9 +110,11 @@ fn compile_bdd(str: String, args: &Args) -> BenchResult {
     let cnf = Cnf::from_file(str);
     let mut man = BddManager::<BddApplyTable<BddPtr>>::new_default_order_lru(cnf.num_vars());
     let _bdd = man.from_cnf(&cnf);
-    BenchResult { num_recursive: man.num_recursive_calls(), size: _bdd.count_nodes() }
+    BenchResult {
+        num_recursive: man.num_recursive_calls(),
+        size: _bdd.count_nodes(),
+    }
 }
-
 
 fn main() {
     let args = Args::parse();
@@ -116,7 +127,7 @@ fn main() {
         "dnnf_topdown" => compile_topdown_nnf(file, &args),
         "sdd_right_linear" => compile_sdd_rightlinear(file, &args),
         "sdd_dtree_topological" => compile_sdd_dtree(file, &args),
-        x => panic!("Unknown mode option: {}", x)
+        x => panic!("Unknown mode option: {}", x),
     };
     let duration = start.elapsed();
 

--- a/bin/one_shot_benchmark.rs
+++ b/bin/one_shot_benchmark.rs
@@ -75,7 +75,7 @@ fn compile_topdown_nnf(str: String, args: &Args) -> BenchResult {
     BenchResult { num_recursive: 0, size: ddnnf.count_nodes() }
 }
 
-fn compile_sdd_dtree(str: String, args: &Args) -> BenchResult {
+fn compile_sdd_dtree(str: String, _args: &Args) -> BenchResult {
     use rsdd::builder::sdd_builder::*;
     let cnf = Cnf::from_file(str);
     let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
@@ -85,7 +85,7 @@ fn compile_sdd_dtree(str: String, args: &Args) -> BenchResult {
 }
 
 
-fn compile_sdd_rightlinear(str: String, args: &Args) -> BenchResult {
+fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
     use rsdd::builder::sdd_builder::*;
     let cnf = Cnf::from_file(str);
     let o : Vec<VarLabel> = (0..cnf.num_vars()).map(|x| VarLabel::new(x as u64)).collect();

--- a/src/backing_store/bump_table.rs
+++ b/src/backing_store/bump_table.rs
@@ -7,7 +7,7 @@ use std::hash::{Hash, Hasher};
 use std::mem;
 
 use crate::util::*;
-use fnv::FnvHasher;
+
 use rustc_hash::FxHasher;
 
 /// The load factor of the table, i.e. how full the table will be when it

--- a/src/builder/cache/all_app.rs
+++ b/src/builder/cache/all_app.rs
@@ -1,10 +1,10 @@
 //! Apply cache for BDD operations that stores all ITEs
-use std::hash::Hash;
 
-use fnv::FnvHashMap;
+
+
 use rustc_hash::FxHashMap;
 
-use crate::repr::{bdd::BddPtr, ddnnf::DDNNFPtr};
+use crate::repr::{ddnnf::DDNNFPtr};
 
 use super::{ite::Ite, LruTable};
 
@@ -16,13 +16,13 @@ pub struct AllTable<T: DDNNFPtr> {
 }
 
 impl<T: DDNNFPtr> LruTable<T> for AllTable<T> {
-    fn hash(&self, ite: &Ite<T>) -> u64 {
+    fn hash(&self, _ite: &Ite<T>) -> u64 {
         // do nothing; the all-cache uses a hashbrown table that caches all applies
         0
     }
 
     /// Insert an ite (f, g, h) into the apply table
-    fn insert(&mut self, ite: Ite<T>, res: T, hash: u64) {
+    fn insert(&mut self, ite: Ite<T>, res: T, _hash: u64) {
         match ite {
             Ite::IteChoice { f, g, h } | Ite::IteComplChoice { f, g, h } => {
                 // convert the ITE into a canonical form
@@ -34,7 +34,7 @@ impl<T: DDNNFPtr> LruTable<T> for AllTable<T> {
         }
     }
 
-    fn get(&mut self, ite: Ite<T>, hash: u64) -> Option<T> {
+    fn get(&mut self, ite: Ite<T>, _hash: u64) -> Option<T> {
         match ite {
             Ite::IteChoice { f, g, h } | Ite::IteComplChoice { f, g, h } => {
                 let r = self.table.get(&(f, g, h));

--- a/src/builder/cache/all_app.rs
+++ b/src/builder/cache/all_app.rs
@@ -1,10 +1,8 @@
 //! Apply cache for BDD operations that stores all ITEs
 
-
-
 use rustc_hash::FxHashMap;
 
-use crate::repr::{ddnnf::DDNNFPtr};
+use crate::repr::ddnnf::DDNNFPtr;
 
 use super::{ite::Ite, LruTable};
 

--- a/src/builder/cache/ite.rs
+++ b/src/builder/cache/ite.rs
@@ -1,7 +1,7 @@
 //! Data-structure for representing ITEs in a standard form
 //! Follows Section 7.1.5, "Standard Triples", in
 //! 'Algorithms and Datastructures in VLSI Design' pages 115-117
-use crate::repr::{bdd::BddPtr, ddnnf::DDNNFPtr, var_order::VarOrder};
+use crate::repr::{ddnnf::DDNNFPtr};
 
 /// Core ITE representation
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Copy)]

--- a/src/builder/cache/ite.rs
+++ b/src/builder/cache/ite.rs
@@ -1,7 +1,7 @@
 //! Data-structure for representing ITEs in a standard form
 //! Follows Section 7.1.5, "Standard Triples", in
 //! 'Algorithms and Datastructures in VLSI Design' pages 115-117
-use crate::repr::{ddnnf::DDNNFPtr};
+use crate::repr::ddnnf::DDNNFPtr;
 
 /// Core ITE representation
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Copy)]

--- a/src/builder/cache/lru_app.rs
+++ b/src/builder/cache/lru_app.rs
@@ -3,10 +3,7 @@ use std::hash::Hasher;
 
 use rustc_hash::FxHasher;
 
-use crate::{
-    repr::{ddnnf::DDNNFPtr},
-    util::lru::*,
-};
+use crate::{repr::ddnnf::DDNNFPtr, util::lru::*};
 
 use super::{ite::Ite, LruTable};
 

--- a/src/builder/cache/lru_app.rs
+++ b/src/builder/cache/lru_app.rs
@@ -4,7 +4,7 @@ use std::hash::Hasher;
 use rustc_hash::FxHasher;
 
 use crate::{
-    repr::{bdd::BddPtr, ddnnf::DDNNFPtr},
+    repr::{ddnnf::DDNNFPtr},
     util::lru::*,
 };
 
@@ -61,7 +61,7 @@ impl<T: DDNNFPtr> LruTable<T> for BddApplyTable<T> {
 }
 
 impl<T: DDNNFPtr> BddApplyTable<T> {
-    pub fn new(num_vars: usize) -> BddApplyTable<T> {
+    pub fn new(_num_vars: usize) -> BddApplyTable<T> {
         BddApplyTable {
             table: Lru::new(INITIAL_CAPACITY),
         }

--- a/src/builder/cache/mod.rs
+++ b/src/builder/cache/mod.rs
@@ -1,4 +1,4 @@
-use crate::repr::{bdd::BddPtr, ddnnf::DDNNFPtr};
+use crate::repr::{ddnnf::DDNNFPtr};
 
 use self::ite::Ite;
 

--- a/src/builder/cache/mod.rs
+++ b/src/builder/cache/mod.rs
@@ -1,4 +1,4 @@
-use crate::repr::{ddnnf::DDNNFPtr};
+use crate::repr::ddnnf::DDNNFPtr;
 
 use self::ite::Ite;
 

--- a/src/builder/decision_nnf_builder.rs
+++ b/src/builder/decision_nnf_builder.rs
@@ -3,7 +3,6 @@
 use crate::{backing_store::*, repr::ddnnf::DDNNFPtr};
 use bumpalo::Bump;
 
-
 use rustc_hash::FxHashMap;
 
 use crate::{

--- a/src/builder/decision_nnf_builder.rs
+++ b/src/builder/decision_nnf_builder.rs
@@ -2,8 +2,8 @@
 
 use crate::{backing_store::*, repr::ddnnf::DDNNFPtr};
 use bumpalo::Bump;
-use num::Num;
-use rand::Rng;
+
+
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -23,7 +23,7 @@ pub struct DecisionNNFBuilder {
 }
 
 impl DecisionNNFBuilder {
-    pub fn new(num_vars: usize) -> DecisionNNFBuilder {
+    pub fn new(_num_vars: usize) -> DecisionNNFBuilder {
         DecisionNNFBuilder {
             compute_table: BackedRobinhoodTable::new(),
         }
@@ -218,7 +218,7 @@ impl DecisionNNFBuilder {
             }
         } else {
             // check cache
-            let idx = match bdd.get_scratch::<BddPtr>() {
+            let _idx = match bdd.get_scratch::<BddPtr>() {
                 None => (),
                 Some(v) => return if bdd.is_neg() { v.neg() } else { *v },
             };

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -568,7 +568,7 @@ impl<'a> SddManager {
     }
 
     /// Compose `g` into `f` by substituting for `lbl`
-    pub fn compose(&mut self, f: SddPtr, lbl: VarLabel, g: SddPtr) -> SddPtr {
+    pub fn compose(&mut self, _f: SddPtr, _lbl: VarLabel, _g: SddPtr) -> SddPtr {
         panic!("not impl")
         // TODO this can be optimized with a specialized implementation to make
         // it a single traversal
@@ -593,7 +593,7 @@ impl<'a> SddManager {
         self.is_compressed_h(f)
     }
 
-    fn is_compressed_h(&self, f: SddPtr) -> bool {
+    fn is_compressed_h(&self, _f: SddPtr) -> bool {
         panic!("not impl")
         // if f.is_const() {
         //     return true;
@@ -626,7 +626,7 @@ impl<'a> SddManager {
         self.is_trimmed_h(f)
     }
 
-    fn is_trimmed_h(&self, f: SddPtr) -> bool {
+    fn is_trimmed_h(&self, _f: SddPtr) -> bool {
         panic!("not impl")
         // if f.is_const() {
         //     return true;
@@ -813,7 +813,7 @@ impl<'a> SddManager {
         }
     }
 
-    pub fn from_logical_expr(&mut self, expr: &LogicalExpr) -> SddPtr {
+    pub fn from_logical_expr(&mut self, _expr: &LogicalExpr) -> SddPtr {
         panic!("not impl")
         // match expr {
         //     &LogicalExpr::Literal(lbl, polarity) => self.var(VarLabel::new(lbl as u64), polarity),

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -205,7 +205,7 @@ impl BddPtr {
     }
 
     /// Print a debug form of the BDD with the label remapping given by `map`
-    pub fn print_bdd_lbl(&self, ptr: BddPtr, map: &HashMap<VarLabel, VarLabel>) -> String {
+    pub fn print_bdd_lbl(&self, _ptr: BddPtr, _map: &HashMap<VarLabel, VarLabel>) -> String {
         panic!("todo")
         // use crate::builder::repr::builder_bdd::PointerType::*;
         // fn print_bdd_helper(
@@ -438,7 +438,7 @@ impl DDNNFPtr for BddPtr {
         }
     }
 
-    fn fold<T: Clone + Copy + Debug, F: Fn(DDNNF<T>) -> T>(&self, o: &VarOrder, f: F) -> T {
+    fn fold<T: Clone + Copy + Debug, F: Fn(DDNNF<T>) -> T>(&self, _o: &VarOrder, f: F) -> T {
         fn bottomup_pass_h<T: Clone + Copy + Debug, F: Fn(DDNNF<T>) -> T>(
             ptr: BddPtr,
             f: &F,

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -3,9 +3,6 @@
 use core::fmt::Debug;
 use num::Num;
 
-
-
-
 use super::{
     var_label::{VarLabel, VarSet},
     wmc::WmcParams,

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -2,12 +2,12 @@
 //! (d-DNNF) pointer type
 use core::fmt::Debug;
 use num::Num;
-use std::collections::HashMap;
 
-use crate::repr::model::PartialModel;
+
+
 
 use super::{
-    var_label::{Literal, VarLabel, VarSet},
+    var_label::{VarLabel, VarSet},
     wmc::WmcParams,
 };
 use std::hash::Hash;

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -6,7 +6,7 @@ use crate::repr::{
     var_label::{VarLabel, VarSet},
 };
 use bumpalo::Bump;
-use std::fmt::{Debug};
+use std::fmt::Debug;
 use SddPtr::*;
 
 // This type is used a lot. Make sure it doesn't unintentionally get bigger.

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -6,7 +6,7 @@ use crate::repr::{
     var_label::{VarLabel, VarSet},
 };
 use bumpalo::Bump;
-use std::fmt::{Binary, Debug};
+use std::fmt::{Debug};
 use SddPtr::*;
 
 // This type is used a lot. Make sure it doesn't unintentionally get bigger.
@@ -303,7 +303,7 @@ impl SddPtr {
 
     pub fn get_var_label(&self) -> VarLabel {
         match &self {
-            Var(v, b) => *v,
+            Var(v, _b) => *v,
             _ => panic!("called get_var on non var"),
         }
     }
@@ -442,7 +442,7 @@ impl DDNNFPtr for SddPtr {
 
     fn fold<T: Clone + Copy + std::fmt::Debug, F: Fn(super::ddnnf::DDNNF<T>) -> T>(
         &self,
-        v: &VTreeManager,
+        _v: &VTreeManager,
         f: F,
     ) -> T {
         fn bottomup_pass_h<T: Clone + Copy + Debug, F: Fn(DDNNF<T>) -> T>(

--- a/src/repr/var_label.rs
+++ b/src/repr/var_label.rs
@@ -1,9 +1,9 @@
 //! A generic data structure for tracking variable labels throughout the library
 use std::fmt;
-use std::mem;
+
 extern crate quickcheck;
 use bit_set::BitSet;
-use bit_set::Intersection;
+
 
 use self::quickcheck::{Arbitrary, Gen};
 

--- a/src/repr/var_label.rs
+++ b/src/repr/var_label.rs
@@ -4,7 +4,6 @@ use std::fmt;
 extern crate quickcheck;
 use bit_set::BitSet;
 
-
 use self::quickcheck::{Arbitrary, Gen};
 
 /// a label for each distinct variable in the BDD

--- a/src/sample/random.rs
+++ b/src/sample/random.rs
@@ -72,7 +72,7 @@ impl<T> Random<T> {
     }
 
     // applies `f` to each component
-    pub fn bind<R>(&self, f: &mut FnMut(&T) -> Random<R>) -> Random<R> {
+    pub fn bind<R>(&self, f: &mut dyn FnMut(&T) -> Random<R>) -> Random<R> {
         let v: Vec<(Random<R>, Probability)> = self.vec().iter().map(|(x, p)| (f(x), *p)).collect();
         let n = Random::from_vec(v);
         Random::flatten(n)

--- a/src/util/lru.rs
+++ b/src/util/lru.rs
@@ -1,10 +1,10 @@
 //! A generic lossy LRU cache
 //! will automatically grow in size if it hits a certain size threshold
 
-use crate::util::*;
-use fnv::FnvHasher;
+
+
 use std::fmt::Debug;
-use std::hash::{Hash, Hasher};
+use std::hash::{Hash};
 
 // if the LRU is GROW_RATIO% full, it will double in size on insertion
 const GROW_RATIO: f64 = 0.7;

--- a/src/util/lru.rs
+++ b/src/util/lru.rs
@@ -1,10 +1,8 @@
 //! A generic lossy LRU cache
 //! will automatically grow in size if it hits a certain size threshold
 
-
-
 use std::fmt::Debug;
-use std::hash::{Hash};
+use std::hash::Hash;
 
 // if the LRU is GROW_RATIO% full, it will double in size on insertion
 const GROW_RATIO: f64 = 0.7;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -294,7 +294,7 @@ mod test_bdd_manager {
     use quickcheck::TestResult;
     use rsdd::builder::cache::all_app::AllTable;
     use rsdd::builder::cache::lru_app::BddApplyTable;
-    
+
     use rsdd::repr::bdd::BddPtr;
     use rsdd::repr::ddnnf::DDNNFPtr;
     use rsdd::repr::model::PartialModel;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -294,7 +294,7 @@ mod test_bdd_manager {
     use quickcheck::TestResult;
     use rsdd::builder::cache::all_app::AllTable;
     use rsdd::builder::cache::lru_app::BddApplyTable;
-    use rsdd::builder::cache::LruTable;
+    
     use rsdd::repr::bdd::BddPtr;
     use rsdd::repr::ddnnf::DDNNFPtr;
     use rsdd::repr::model::PartialModel;


### PR DESCRIPTION
Tidying up some warnings! Ran `cargo test` to validate that no tests change, and all of these changes are nondestructive (there's no hot code path, etc). Vast majority are:

- unused imports (these are removed)
- unused arguments (these get autoprefixed with `_`)

Now, only left with 4 warnings

```
$ cargo build
warning: unused manifest key: build
   Compiling rsdd v0.1.0 (/Users/matt/code/rsdd)
warning: associated function `get_pos` is never used
   --> src/backing_store/bump_table.rs:121:8
    |
121 |     fn get_pos(&self, pos: usize) -> *mut T {
    |        ^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: associated function `num_nodes` is never used
   --> src/backing_store/bump_table.rs:151:12
    |
151 |     pub fn num_nodes(&self) -> usize {
    |            ^^^^^^^^^

warning: function `sdd_wmc1` is never used
    --> src/builder/sdd_builder.rs:1095:4
     |
1095 | fn sdd_wmc1() {
     |    ^^^^^^^^

warning: struct `UniquePtr` is never constructed
 --> src/unique_table/mod.rs:4:8
  |
4 | struct UniquePtr<T: Hash + Eq + PartialEq>(*const T);
  |        ^^^^^^^^^

warning: `rsdd` (lib) generated 4 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 1.60s
```

Fixing these probably requires some actual live code changes, so I've elected to not put them in for now.