### PR TITLE
Implements `Arbitrary` for `VTree`, more `isCanonical` tests

### DIFF
--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -487,7 +487,7 @@ impl SddPtr {
             BDD(_) => {
                 // core assumption: in binary SDD, the prime is always x and not x
                 // so, we only check low/high being flipped versions
-                if (!self.low().is_const() || !self.high().is_const()) {
+                if !self.low().is_const() || !self.high().is_const() {
                     return self.low().is_trimmed() && self.high().is_trimmed();
                 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -651,7 +651,7 @@ mod test_sdd_manager {
     }
 
     quickcheck! {
-        fn sdd_compressed_default(c: Cnf) -> bool {
+        fn sdd_compressed_right_linear(c: Cnf) -> bool {
             let order : Vec<VarLabel> = (0..16).map(VarLabel::new).collect();
             let vtree = VTree::right_linear(&order);
             let mut mgr = super::SddManager::new(vtree);
@@ -661,17 +661,29 @@ mod test_sdd_manager {
     }
 
     quickcheck! {
-        fn sdd_trimmed_default(c: Cnf) -> bool {
+        fn sdd_trimmed_right_linear(c: Cnf) -> bool {
             let order : Vec<VarLabel> = (0..16).map(VarLabel::new).collect();
             let vtree = VTree::right_linear(&order);
             let mut mgr = super::SddManager::new(vtree);
             let cnf = mgr.from_cnf(&c);
 
-            if !cnf.is_trimmed() {
-                println!("{}", mgr.print_sdd(cnf))
-            }
+            cnf.is_trimmed()
+        }
+    }
 
-            true
+    quickcheck! {
+        fn sdd_compressed_arbitrary_vtree(c: Cnf, vtree: VTree) -> bool {
+            let mut mgr = super::SddManager::new(vtree);
+            let cnf = mgr.from_cnf(&c);
+            cnf.is_compressed()
+        }
+    }
+
+    quickcheck! {
+        fn sdd_trimmed_arbitrary_vtree(c: Cnf, vtree: VTree) -> bool {
+            let mut mgr = super::SddManager::new(vtree);
+            let cnf = mgr.from_cnf(&c);
+            cnf.is_trimmed()
         }
     }
 }


### PR DESCRIPTION
This PR implements quickcheck's `Arbitrary` for `VTree`. The goal is to be able to generate arbitrary SDDs by iterating through random CNFs and corresponding VTrees; I write two quickcheck tests as an example.

Nothing too complicated in terms of implementation; the quick summary:

- get RNG seed from `Gen`
- shuffle a vector of 16 variable labels (this is one of two types of random events)
- then, "randomly split"
    - trivial results on `1`, `2`; panics at `0`
    - otherwise, split the slice of labels in a way that guarantees that there's always at least one label in each slice
    - then, recursively split the two sub-slices, and join them together in a node