### PR TITLE
Resolves most cases of `dead_code`, `unused_variables`

### DIFF
--- a/bin/one_shot_benchmark.rs
+++ b/bin/one_shot_benchmark.rs
@@ -63,9 +63,7 @@ struct BenchResult {
     size: usize,
 }
 
-// TODO: resolve unused
-#[allow(unused)]
-fn compile_topdown_nnf(str: String, args: &Args) -> BenchResult {
+fn compile_topdown_nnf(str: String, _args: &Args) -> BenchResult {
     let cnf = Cnf::from_file(str);
     let mut man = rsdd::builder::decision_nnf_builder::DecisionNNFBuilder::new(cnf.num_vars());
     let order = VarOrder::linear_order(cnf.num_vars());
@@ -103,9 +101,7 @@ fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
     }
 }
 
-// TODO: resolve unused
-#[allow(unused)]
-fn compile_bdd(str: String, args: &Args) -> BenchResult {
+fn compile_bdd(str: String, _args: &Args) -> BenchResult {
     use rsdd::builder::bdd_builder::*;
     let cnf = Cnf::from_file(str);
     let mut man = BddManager::<BddApplyTable<BddPtr>>::new_default_order_lru(cnf.num_vars());

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -12,7 +12,6 @@ use crate::backing_store::UniqueTable;
 use crate::repr::ddnnf::DDNNFPtr;
 use crate::repr::sdd::{BinarySDD, SddAnd, SddOr, SddPtr};
 use crate::repr::vtree::{VTree, VTreeIndex, VTreeManager};
-use crate::repr::wmc::WmcParams;
 use crate::{repr::cnf::Cnf, repr::logical_expr::LogicalExpr, repr::var_label::VarLabel};
 
 #[derive(Debug, Clone)]
@@ -999,7 +998,7 @@ fn sdd_circuit2() {
     );
 }
 
-// #[test]
+#[test]
 fn sdd_wmc1() {
     // modeling the formula (x<=>fx) && (y<=>fy), with f weight of 0.5
 
@@ -1022,7 +1021,7 @@ fn sdd_wmc1() {
         1,
     );
     let mut man = SddManager::new(vtree.clone());
-    let mut wmc_map = WmcParams::new(0.0, 1.0);
+    let mut wmc_map = crate::repr::wmc::WmcParams::new(0.0, 1.0);
     let x = SddPtr::var(VarLabel::new(0), true);
     wmc_map.set_weight(VarLabel::new(0), 1.0, 1.0);
     let y = SddPtr::var(VarLabel::new(1), true);

--- a/src/repr/dtree.rs
+++ b/src/repr/dtree.rs
@@ -33,14 +33,14 @@ pub enum DTree {
 impl DTree {
     fn get_vars(&self) -> &VarSet {
         match self {
-            // TODO: resolve unused
-            #[allow(unused)]
-            Self::Leaf { v, cutset: _, vars } => vars.as_ref().unwrap(),
-            // TODO: resolve unused
-            #[allow(unused)]
+            Self::Leaf {
+                v: _,
+                cutset: _,
+                vars,
+            } => vars.as_ref().unwrap(),
             Self::Node {
-                l,
-                r,
+                l: _,
+                r: _,
                 cutset: _,
                 vars,
             } => vars.as_ref().unwrap(),
@@ -70,11 +70,9 @@ impl DTree {
                 *vars = Some(r.clone());
                 r
             }
-            // TODO: resolve unused
-            #[allow(unused)]
             Self::Node {
-                l,
-                r,
+                l: _,
+                r: _,
                 cutset: _,
                 ref mut vars,
             } if vars.is_some() => vars.as_ref().unwrap().clone(),
@@ -240,12 +238,10 @@ impl DTree {
     /// Programming. Springer, Cham, 2014.
     pub fn to_vtree(&self) -> Option<VTree> {
         match &self {
-            // TODO: resolve unused
-            #[allow(unused)]
             &Self::Leaf {
                 v: _v,
                 cutset,
-                vars,
+                vars: _,
             } => {
                 let cutset_v: Vec<VarLabel> = cutset
                     .clone()
@@ -259,9 +255,12 @@ impl DTree {
                     Some(DTree::right_linear(cutset_v.as_slice(), &None))
                 }
             }
-            // TODO: resolve unused
-            #[allow(unused)]
-            &Self::Node { l, r, cutset, vars } => {
+            &Self::Node {
+                l,
+                r,
+                cutset,
+                vars: _,
+            } => {
                 let cutset_v: Vec<VarLabel> = cutset
                     .clone()
                     .unwrap()
@@ -285,11 +284,18 @@ impl DTree {
     }
 
     pub fn width(&self) -> usize {
-        // TODO: resolve unused
-        #[allow(unused)]
         match &self {
-            &Self::Leaf { v, cutset, vars } => cutset.as_ref().unwrap().len(),
-            &Self::Node { l, r, cutset, vars } => {
+            &Self::Leaf {
+                v: _,
+                cutset,
+                vars: _,
+            } => cutset.as_ref().unwrap().len(),
+            &Self::Node {
+                l,
+                r,
+                cutset,
+                vars: _,
+            } => {
                 let l_len = l.width();
                 let r_len = r.width();
                 let cur = cutset.as_ref().unwrap().len();

--- a/src/util/hypergraph.rs
+++ b/src/util/hypergraph.rs
@@ -1,5 +1,5 @@
 // TODO: remove crate-level disable
-#![allow(dead_code, unused_imports, unused_variables)]
+#![allow(unused_imports)]
 
 use crate::repr::cnf::Cnf;
 use crate::repr::var_label::{Literal, VarLabel};
@@ -28,7 +28,7 @@ impl<T: Clone + Debug + PartialEq + Eq + Hash> Hypergraph<T> {
 
     /// assumes that hyperedges only includes elements from vertices
     fn cache_from(
-        vertices: &HashSet<T>,
+        _vertices: &HashSet<T>,
         hyperedges: &Vec<HashSet<T>>,
     ) -> HashMap<T, HashSet<usize>> {
         let mut assoc_cache: HashMap<T, HashSet<usize>> = HashMap::new();
@@ -143,7 +143,7 @@ impl<T: Clone + Debug + PartialEq + Eq + Hash> Hypergraph<T> {
             self.vertices = vertices;
         }
 
-        let next_ix = self.hyperedges.len();
+        let _next_ix = self.hyperedges.len();
         match self.hyperedges.clone().iter().find(|e| e == &edge) {
             Some(_) => return false,
             None => self.hyperedges.push(edge.clone()),
@@ -286,7 +286,7 @@ mod test {
         let cnf = Cnf::new(v);
         let ig = cnf.interaction_graph();
         println!("{:?}", Dot::with_config(&ig, &[Config::EdgeNoLabel]));
-        let nodes = ig
+        let _nodes = ig
             .raw_nodes()
             .iter()
             .map(|n| n.weight.clone())
@@ -362,7 +362,7 @@ mod test {
         }
         assert_eq!(hg.vertices, HashSet::from([2, 5, 7]));
 
-        let edges_api = hg.edges();
+        let _edges_api = hg.edges();
         for s in [HashSet::from([2, 5, 7]), HashSet::from([2])] {
             assert!(hg.hyperedges.iter().any(|e| e == &s));
         }
@@ -463,17 +463,17 @@ mod test {
                 let mut tmp = g.clone();
                 tmp.cut_vertex(&v);
                 // naive take 1
-                let mx_width: f64 = tmp.widths().1 as f64;
+                let _mx_width: f64 = tmp.widths().1 as f64;
                 // naive take 2
-                let mx_edge_size = tmp.edges().iter().map(|e| e.len()).max().unwrap() as f64;
+                let _mx_edge_size = tmp.edges().iter().map(|e| e.len()).max().unwrap() as f64;
                 // expectation over edge sizes
                 let sum_edge_size: f64 = tmp.edges().iter().map(|e| e.len() as f64).sum();
-                let mean_edge_size = sum_edge_size / tmp.size() as f64;
+                let _mean_edge_size = sum_edge_size / tmp.size() as f64;
 
                 // for each variable
                 // iterate through each node it would cut
                 let edges_for_v = g.edges_for(v);
-                let max_edge_size = edges_for_v.iter().map(|e| e.len()).max().unwrap() as f64;
+                let _max_edge_size = edges_for_v.iter().map(|e| e.len()).max().unwrap() as f64;
 
                 let (new_num_edges, total_acc) =
                     g.edges().iter().fold((0_f64, 0_f64), |(count, acc), e| {
@@ -488,7 +488,7 @@ mod test {
                             (count + 1.0, acc + 2_f64.powf(l))
                         }
                     });
-                let max_potential_combinations = total_acc / new_num_edges;
+                let _max_potential_combinations = total_acc / new_num_edges;
 
                 // largest cover after cut heuristic
                 let cut_cover_widths = g
@@ -507,14 +507,14 @@ mod test {
                                 .collect();
                             let cs = Hypergraph::edges_to_covers(newes.clone().iter().collect())
                                 .iter()
-                                .map(|(c, es)| es.len() as f64)
+                                .map(|(_c, es)| es.len() as f64)
                                 .collect();
                             cs
                         }
                     })
                     .collect::<Vec<f64>>();
 
-                let avg_cut_cover_widths =
+                let _avg_cut_cover_widths =
                     (-1.0) * cut_cover_widths.iter().sum::<f64>() / cut_cover_widths.len() as f64;
                 let max_cut_cover_widths = (-1.0)
                     * cut_cover_widths


### PR DESCRIPTION
Everything in this PR is a no-op.

However, there were a handful of things I couldn't fix:

- the `PRIMES` array in `cnf.rs` is actually unused. but it seems useful. I think I'll use it for the prove equiv check 
- `hypergraph.rs` has some false positives for `unused_imports`:
    - some of the imports are used in test code; even if i scope the crate import to the test `mod`, it *still* has a warning!
    - I may do some more digging here, I'm curious why this doesn't work!
- `importance_sampler.rs`'s `is_valid()` has a `todo()!`, so I didn't touch it 
- `bump_table.rs` has two unused functions: `get_nodes()` and `num_nodes()`; not going to actually remove any code from the codebase