### PR TITLE
Makes `cargo build --all` emit no warnings, rename CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   push:
     branches: [ master ]

--- a/src/backing_store/bump_table.rs
+++ b/src/backing_store/bump_table.rs
@@ -118,6 +118,7 @@ where
         self.tbl[pos].is_occupied()
     }
 
+    #[allow(dead_code)]
     fn get_pos(&self, pos: usize) -> *mut T {
         self.tbl[pos].ptr
     }
@@ -148,6 +149,7 @@ where
     //     (total as f64) / (self.len as f64)
     // }
 
+    #[allow(dead_code)]
     pub fn num_nodes(&self) -> usize {
         self.len
     }

--- a/src/unique_table/mod.rs
+++ b/src/unique_table/mod.rs
@@ -1,6 +1,7 @@
 //! Internal module for unique tables, used for memoizing decision diagram nodes
 use std::hash::Hash;
 
+#[allow(dead_code)]
 struct UniquePtr<T: Hash + Eq + PartialEq>(*const T);
 
 /// Core UniqueTable trait that stores and memoizes unique nodes


### PR DESCRIPTION
Two disjoint things that I'm bundling into this PR:

- add `#allow[(dead_code)]` to the three instances I discussed in #39 
- give a name to the CI workflow (it's a filename right now)

Moving forward, this should make it more clear when we introduce a lint warning/error with new code!

(there's technically still one non-code warning: `unused manifest key build`. Not sure how this key is used, but it seems like it's somewhat important?)