### PR TITLE
Fixes all warnings flagged by `cargo clippy`, add `clippy` to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: cargo fmt --all -- --check
+    - run: cargo clippy --all
 
   test:
     name: test

--- a/bin/bayesian_network_compiler.rs
+++ b/bin/bayesian_network_compiler.rs
@@ -124,6 +124,7 @@ struct Args {
 }
 
 /// construct a CNF for the two TERMS (i.e., conjunctions of literals) t1 => t2
+#[allow(clippy::ptr_arg)]
 fn implies(t1: &Vec<Literal>, t2: &Vec<Literal>) -> Vec<Vec<Literal>> {
     let mut r: Vec<Vec<Literal>> = Vec::new();
     // negate the lhs

--- a/bin/compare_canonicalize.rs
+++ b/bin/compare_canonicalize.rs
@@ -30,6 +30,7 @@ struct Args {
 }
 
 /// construct a CNF for the two TERMS (i.e., conjunctions of literals) t1 => t2
+#[allow(clippy::ptr_arg)]
 fn implies(t1: &Vec<Literal>, t2: &Vec<Literal>) -> Vec<Vec<Literal>> {
     let mut r: Vec<Vec<Literal>> = Vec::new();
     // negate the lhs

--- a/src/backing_store/bump_table.rs
+++ b/src/backing_store/bump_table.rs
@@ -30,7 +30,7 @@ struct HashTableElement<T: Clone> {
 impl<T: Clone> Default for HashTableElement<T> {
     fn default() -> Self {
         HashTableElement {
-            ptr: 0 as *mut T,
+            ptr: std::ptr::null_mut::<T>(),
             hash: 0,
             psl: 0,
         }
@@ -39,15 +39,12 @@ impl<T: Clone> Default for HashTableElement<T> {
 
 impl<T: Clone> HashTableElement<T> {
     pub fn new(ptr: *mut T, hash: u64, psl: u8) -> HashTableElement<T> {
-        HashTableElement {
-            ptr,
-            hash,
-            psl: psl,
-        }
+        HashTableElement { ptr, hash, psl }
     }
 
+    #[allow(clippy::cmp_null)] // TODO: fix. unsure why the suggestion (using is_null) doesn't work
     pub fn is_occupied(&self) -> bool {
-        return self.ptr != 0 as *mut T;
+        self.ptr != std::ptr::null_mut::<T>()
     }
 }
 
@@ -55,7 +52,7 @@ impl<T: Clone> HashTableElement<T> {
 /// is used during growing and after an element has been found during
 /// `get_or_insert`
 fn propagate<T: Clone>(
-    v: &mut Vec<HashTableElement<T>>,
+    v: &mut [HashTableElement<T>],
     cap: usize,
     itm: HashTableElement<T>,
     pos: usize,

--- a/src/builder/bdd_plan.rs
+++ b/src/builder/bdd_plan.rs
@@ -1,7 +1,5 @@
 //! Represents a deferred BDD computation
 
-// use super::var_label::Literal;
-
 #[derive(Debug, Clone)]
 pub enum BddPlan {
     And(Box<BddPlan>, Box<BddPlan>),
@@ -15,6 +13,7 @@ pub enum BddPlan {
 }
 
 impl BddPlan {
+    #[allow(clippy::should_implement_trait)] // TODO: this should probably be renamed not compl?
     pub fn not(p: BddPlan) -> Self {
         Self::Not(Box::new(p))
     }

--- a/src/builder/cache/all_app.rs
+++ b/src/builder/cache/all_app.rs
@@ -55,3 +55,9 @@ impl<T: DDNNFPtr> AllTable<T> {
         }
     }
 }
+
+impl<T: DDNNFPtr> Default for AllTable<T> {
+    fn default() -> AllTable<T> {
+        Self::new()
+    }
+}

--- a/src/builder/cache/ite.rs
+++ b/src/builder/cache/ite.rs
@@ -61,35 +61,26 @@ impl<T: DDNNFPtr> Ite<T> {
 
         // now, standardize for negation: ensure f and g are non-negated
         match (f, g, h) {
-            (f, g, h) if f.is_neg() && !h.is_neg() => {
-                return IteChoice {
-                    f: f.neg(),
-                    g: h,
-                    h: g,
-                }
-            }
-            (f, g, h) if !f.is_neg() && g.is_neg() => {
-                return IteComplChoice {
-                    f,
-                    g: g.neg(),
-                    h: h.neg(),
-                }
-            }
-            (f, g, h) if f.is_neg() && h.is_neg() => {
-                return IteComplChoice {
-                    f: f.neg(),
-                    g: h.neg(),
-                    h: g.neg(),
-                }
-            }
-            _ => return IteChoice { f, g, h },
+            (f, g, h) if f.is_neg() && !h.is_neg() => IteChoice {
+                f: f.neg(),
+                g: h,
+                h: g,
+            },
+            (f, g, h) if !f.is_neg() && g.is_neg() => IteComplChoice {
+                f,
+                g: g.neg(),
+                h: h.neg(),
+            },
+            (f, g, h) if f.is_neg() && h.is_neg() => IteComplChoice {
+                f: f.neg(),
+                g: h.neg(),
+                h: g.neg(),
+            },
+            _ => IteChoice { f, g, h },
         }
     }
 
     pub fn is_compl_choice(&self) -> bool {
-        match &self {
-            IteComplChoice { f: _, g: _, h: _ } => true,
-            _ => false,
-        }
+        matches!(self, IteComplChoice { f: _, g: _, h: _ })
     }
 }

--- a/src/builder/cache/lru_app.rs
+++ b/src/builder/cache/lru_app.rs
@@ -50,7 +50,7 @@ impl<T: DDNNFPtr> LruTable<T> for BddApplyTable<T> {
                 f.hash(&mut hasher);
                 g.hash(&mut hasher);
                 h.hash(&mut hasher);
-                return hasher.finish();
+                hasher.finish()
             }
             Ite::IteConst(_) => 0, // do not cache base-cases
         }

--- a/src/builder/cache/sdd_apply_cache.rs
+++ b/src/builder/cache/sdd_apply_cache.rs
@@ -15,7 +15,13 @@ impl SddApply {
     pub fn get(&self, and: SddAnd) -> Option<SddPtr> {
         self.table.get(&and).cloned()
     }
-    pub fn insert(&mut self, and: SddAnd, ptr: SddPtr) -> () {
+    pub fn insert(&mut self, and: SddAnd, ptr: SddPtr) {
         self.table.insert(and, ptr);
+    }
+}
+
+impl Default for SddApply {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/builder/decision_nnf_builder.rs
+++ b/src/builder/decision_nnf_builder.rs
@@ -217,10 +217,10 @@ impl DecisionNNFBuilder {
             }
         } else {
             // check cache
-            let _idx = match bdd.get_scratch::<BddPtr>() {
-                None => (),
-                Some(v) => return if bdd.is_neg() { v.neg() } else { *v },
-            };
+            // let _idx = match bdd.get_scratch::<BddPtr>() {
+            //     None => (),
+            //     Some(v) => return if bdd.is_neg() { v.neg() } else { *v },
+            // };
 
             // recurse on the children
             let n = bdd.into_node();

--- a/src/repr/cnf.rs
+++ b/src/repr/cnf.rs
@@ -9,6 +9,7 @@ use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 extern crate quickcheck;
 use self::quickcheck::{Arbitrary, Gen};
 use crate::repr::model::PartialModel;
@@ -173,12 +174,12 @@ impl CnfHasher {
                     cur_clause_v = cur_clause_v.wrapping_mul(*weight as u128);
                 }
             }
-            for i in 0..NUM_PRIMES {
+            for i in v.iter_mut().take(NUM_PRIMES) {
                 // TODO at the moment this modular multiplication is very slow; we should use a
                 // crate that supports fast modular multiplication for fixed prime fields
                 // using just 128-bit for now, but this is a hack
                 // v[i] = (v[i]* (cur_clause_v)) % PRIMES[i];
-                v[i] = v[i].wrapping_mul(cur_clause_v);
+                *i = i.wrapping_mul(cur_clause_v);
             }
         }
         HashedCNF { v }
@@ -276,7 +277,7 @@ impl Cnf {
                 m = max(lit.get_label().value() + 1, m);
             }
             // remove duplicate literals
-            clause.sort_by(|a, b| a.get_label().value().cmp(&b.get_label().value()));
+            clause.sort_by_key(|a| a.get_label().value());
             clause.dedup();
         }
 
@@ -408,14 +409,11 @@ impl Cnf {
         for clause in self.clauses.iter() {
             let mut clause_sat = false;
             for lit in clause.iter() {
-                match partial_assignment.get(lit.get_label()) {
-                    Some(assgn) => {
-                        if lit.get_polarity() == assgn {
-                            clause_sat = true;
-                        }
+                if let Some(assgn) = partial_assignment.get(lit.get_label()) {
+                    if lit.get_polarity() == assgn {
+                        clause_sat = true;
                     }
-                    None => (),
-                };
+                }
             }
             if !clause_sat {
                 return false;
@@ -530,7 +528,7 @@ impl Cnf {
             let l = avg_cog.len();
             let mut avg_cog: Vec<(f64, usize)> = avg_cog.into_iter().zip(0..l).collect();
             // now sort avg_cog on the centers of gravity
-            avg_cog.sort_by(|&(ref c1, _), &(ref c2, _)| c1.partial_cmp(c2).unwrap());
+            avg_cog.sort_by(|(c1, _), (c2, _)| c1.partial_cmp(c2).unwrap());
             // update positions
             let pos_to_lbl: Vec<usize> = avg_cog.into_iter().map(|(_, p)| p).collect();
             // now convert to lbl_to_pos
@@ -556,14 +554,10 @@ impl Cnf {
             .iter()
             .filter_map(|clause| {
                 // first, check if there is a true literal -- if there is, filter out this clause
-                if clause
-                    .iter()
-                    .find(|outer| {
-                        outer.get_label() == lit.get_label()
-                            && outer.get_polarity() == lit.get_polarity()
-                    })
-                    .is_some()
-                {
+                if clause.iter().any(|outer| {
+                    outer.get_label() == lit.get_label()
+                        && outer.get_polarity() == lit.get_polarity()
+                }) {
                     None
                 } else {
                     // next, filter out clauses with false literals
@@ -580,31 +574,6 @@ impl Cnf {
             })
             .collect();
         Cnf::new(new_cnf)
-    }
-
-    pub fn to_string(&self) -> String {
-        let mut r = String::new();
-        for clause in self.clauses.iter() {
-            let mut clause_str = String::new();
-            for lit in clause.iter() {
-                let lit_str = format!(
-                    "{}{}",
-                    if lit.get_polarity() { "" } else { "!" },
-                    lit.get_label().value()
-                );
-                if clause_str.is_empty() {
-                    clause_str = lit_str;
-                } else {
-                    clause_str = format!("{} || {}", clause_str, lit_str);
-                }
-            }
-            if r.is_empty() {
-                r = format!("({})", clause_str);
-            } else {
-                r = format!(" {} && ({})", r, clause_str);
-            }
-        }
-        r
     }
 
     pub fn interaction_graph(&self) -> UnGraph<VarLabel, ()> {
@@ -693,6 +662,33 @@ impl Arbitrary for Cnf {
             clauses.push(clause);
         }
         Cnf::new(clauses)
+    }
+}
+
+impl fmt::Display for Cnf {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut r = String::new();
+        for clause in self.clauses.iter() {
+            let mut clause_str = String::new();
+            for lit in clause.iter() {
+                let lit_str = format!(
+                    "{}{}",
+                    if lit.get_polarity() { "" } else { "!" },
+                    lit.get_label().value()
+                );
+                if clause_str.is_empty() {
+                    clause_str = lit_str;
+                } else {
+                    clause_str = format!("{} || {}", clause_str, lit_str);
+                }
+            }
+            if r.is_empty() {
+                r = format!("({})", clause_str);
+            } else {
+                r = format!(" {} && ({})", r, clause_str);
+            }
+        }
+        write!(f, "{}", r)
     }
 }
 

--- a/src/repr/dtree.rs
+++ b/src/repr/dtree.rs
@@ -2,7 +2,7 @@
 //! A dtree describes a decomposition structure on clauses of a CNF. See Chapter
 //! 9.5 of 'Modeling and Reasoning with Bayesian Networks' by Adnan Darwiche
 
-use std::{cmp::Ordering, iter::FromIterator};
+use std::cmp::Ordering;
 
 use crate::repr::{
     cnf::Cnf,
@@ -37,27 +37,37 @@ pub enum DTree {
 impl DTree {
     fn get_vars(&self) -> &VarSet {
         match self {
-            DTree::Node { l, r, cutset, vars } => &vars,
-            DTree::Leaf {
-                clause,
-                cutset,
+            DTree::Node {
+                l: _,
+                r: _,
+                cutset: _,
                 vars,
-            } => &vars,
+            } => vars,
+            DTree::Leaf {
+                clause: _,
+                cutset: _,
+                vars,
+            } => vars,
         }
     }
 
     /// initialize the set of vars so that, for each node, it holds that
     /// vars = vars(l) ∪ vars(r)
-    fn init_vars(&mut self) -> () {
+    fn init_vars(&mut self) {
         match self {
-            DTree::Node { l, r, cutset, vars } => {
+            DTree::Node {
+                l,
+                r,
+                cutset: _,
+                vars,
+            } => {
                 l.init_vars();
                 r.init_vars();
                 *vars = l.get_vars().union(r.get_vars());
             }
             DTree::Leaf {
                 clause,
-                cutset,
+                cutset: _,
                 vars,
             } => {
                 for c in clause.iter() {
@@ -69,7 +79,12 @@ impl DTree {
 
     fn gen_cutset(&mut self, ancestor_cutset: &VarSet) {
         match self {
-            DTree::Node { l, r, cutset, vars } => {
+            DTree::Node {
+                l,
+                r,
+                cutset,
+                vars: _,
+            } => {
                 // cutset of a node is defined (vars(l) ∩ vars(r)) \ ancestor cutset
                 let intersect = l.get_vars().intersect_varset(r.get_vars());
                 let my_cutset = intersect.minus(ancestor_cutset);
@@ -78,7 +93,7 @@ impl DTree {
                 *cutset = my_cutset;
             }
             DTree::Leaf {
-                clause,
+                clause: _,
                 cutset,
                 vars,
             } => {
@@ -216,11 +231,11 @@ impl DTree {
     /// International Conference on Principles and Practice of Constraint
     /// Programming. Springer, Cham, 2014.
     pub fn to_vtree(&self) -> Option<VTree> {
-        match &self {
-            &Self::Leaf {
-                clause,
+        match &&self {
+            Self::Leaf {
+                clause: _,
                 cutset,
-                vars,
+                vars: _,
             } => {
                 let cutset_v: Vec<VarLabel> = cutset.iter().collect();
                 if cutset.is_empty() {
@@ -229,7 +244,7 @@ impl DTree {
                     Some(DTree::right_linear(cutset_v.as_slice(), &None))
                 }
             }
-            &Self::Node {
+            Self::Node {
                 l,
                 r,
                 cutset,
@@ -253,13 +268,13 @@ impl DTree {
     }
 
     pub fn width(&self) -> usize {
-        match &self {
-            &Self::Leaf {
-                clause,
+        match &&self {
+            Self::Leaf {
+                clause: _,
                 cutset,
-                vars,
+                vars: _,
             } => cutset.iter().count(),
-            &Self::Node {
+            Self::Node {
                 l,
                 r,
                 cutset,

--- a/src/repr/logical_expr.rs
+++ b/src/repr/logical_expr.rs
@@ -110,43 +110,43 @@ impl LogicalExpr {
 
     /// Evaluates a boolean expression
     pub fn eval(&self, values: &HashMap<VarLabel, bool>) -> bool {
-        match self {
-            &LogicalExpr::Literal(lbl, polarity) => {
-                let v = match values.get(&(VarLabel::new(lbl as u64))) {
+        match &self {
+            LogicalExpr::Literal(lbl, polarity) => {
+                let v = match values.get(&(VarLabel::new(*lbl as u64))) {
                     None => panic!("Variable {} not found in varset", lbl),
                     Some(a) => a,
                 };
-                if polarity {
+                if *polarity {
                     *v
                 } else {
                     !*v
                 }
             }
-            &LogicalExpr::Not(ref l) => {
+            LogicalExpr::Not(ref l) => {
                 let v = (*l).eval(values);
                 !v
             }
-            &LogicalExpr::And(ref l, ref r) => {
+            LogicalExpr::And(ref l, ref r) => {
                 let l_v = (*l).eval(values);
                 let r_v = (*r).eval(values);
                 l_v && r_v
             }
-            &LogicalExpr::Or(ref l, ref r) => {
+            LogicalExpr::Or(ref l, ref r) => {
                 let l_v = (*l).eval(values);
                 let r_v = (*r).eval(values);
                 l_v || r_v
             }
-            &LogicalExpr::Iff(ref l, ref r) => {
+            LogicalExpr::Iff(ref l, ref r) => {
                 let l_v = (*l).eval(values);
                 let r_v = (*r).eval(values);
                 l_v == r_v
             }
-            &LogicalExpr::Xor(ref l, ref r) => {
+            LogicalExpr::Xor(ref l, ref r) => {
                 let l_v = (*l).eval(values);
                 let r_v = (*r).eval(values);
                 (!l_v && r_v) || (l_v && !r_v)
             }
-            &LogicalExpr::Ite {
+            LogicalExpr::Ite {
                 ref guard,
                 ref thn,
                 ref els,

--- a/src/repr/model.rs
+++ b/src/repr/model.rs
@@ -68,14 +68,14 @@ impl PartialModel {
     }
 
     /// Produces an iterator of all the assigned literals
-    pub fn assignment_iter<'a>(&'a self) -> impl Iterator<Item = Literal> + 'a {
+    pub fn assignment_iter(&self) -> impl Iterator<Item = Literal> + '_ {
         self.assignments.iter().enumerate().filter_map(|(idx, x)| {
             x.as_ref()
                 .map(|v| Literal::new(VarLabel::new_usize(idx), *v))
         })
     }
 
-    pub fn unassigned_vars<'a>(&'a self) -> impl Iterator<Item = VarLabel> + 'a {
+    pub fn unassigned_vars(&self) -> impl Iterator<Item = VarLabel> + '_ {
         self.assignments
             .iter()
             .enumerate()

--- a/src/repr/sat_solver.rs
+++ b/src/repr/sat_solver.rs
@@ -206,13 +206,9 @@ impl<'a> UnitPropagate<'a> {
             }
 
             // gather a list of all remaining unassigned literals in the current clause
-            let mut remaining_lits =
-                clause
-                    .iter()
-                    .filter(|x| match self.cur_state().get(x.get_label()) {
-                        None => true,
-                        Some(_) => false,
-                    });
+            let mut remaining_lits = clause
+                .iter()
+                .filter(|x| self.cur_state().get(x.get_label()).is_none());
 
             let num_remaining = remaining_lits.clone().count();
             if num_remaining == 0 {
@@ -284,6 +280,7 @@ impl<'a> UnitPropagate<'a> {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum SATState {
     UNSAT, // the state is currently unsatisfied according to the units in the CNF
@@ -374,10 +371,7 @@ impl<'a> SATSolver<'a> {
     /// True if the formula is UNSAT according to the current state of the
     /// decided units
     pub fn unsat_unit(&self) -> bool {
-        match self.top_state() {
-            SATState::UNSAT => true,
-            _ => false,
-        }
+        matches!(self.top_state(), SATState::UNSAT)
     }
 
     /// Get the set of currently implied units

--- a/src/repr/var_label.rs
+++ b/src/repr/var_label.rs
@@ -99,13 +99,13 @@ impl VarSet {
     }
 
     /// unions self with other in-place
-    pub fn union_with(&mut self, other: &VarSet) -> () {
+    pub fn union_with(&mut self, other: &VarSet) {
         self.b.union_with(&other.b);
     }
 
     /// unions self with other in-place
     pub fn iter(&self) -> impl Iterator<Item = VarLabel> + '_ {
-        self.b.iter().map(|x| VarLabel::new_usize(x))
+        self.b.iter().map(VarLabel::new_usize)
     }
 
     /// unions self with other
@@ -122,7 +122,7 @@ impl VarSet {
         }
     }
 
-    pub fn insert(&mut self, v: VarLabel) -> () {
+    pub fn insert(&mut self, v: VarLabel) {
         self.b.insert(v.value_usize());
     }
 
@@ -131,7 +131,7 @@ impl VarSet {
     }
 
     pub fn intersect<'a>(&'a self, other: &'a VarSet) -> bit_set::Intersection<'a, u32> {
-        return self.b.intersection(&other.b);
+        self.b.intersection(&other.b)
     }
 
     pub fn intersect_varset<'a>(&'a self, other: &'a VarSet) -> VarSet {
@@ -142,5 +142,11 @@ impl VarSet {
 
     pub fn is_empty(&self) -> bool {
         self.b.is_empty()
+    }
+}
+
+impl Default for VarSet {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/repr/var_order.rs
+++ b/src/repr/var_order.rs
@@ -127,13 +127,13 @@ impl VarOrder {
     }
 
     /// Iterate through the variables in the order in which they appear in the order
-    pub fn in_order_iter<'a>(&'a self) -> impl Iterator<Item = VarLabel> + 'a {
+    pub fn in_order_iter(&self) -> impl Iterator<Item = VarLabel> + '_ {
         self.pos_to_var.iter().map(|x| VarLabel::new_usize(*x))
     }
 
     /// Iterate through the variables in the the reverse order in which they
     /// appear in the order
-    pub fn reverse_in_order_iter<'a>(&'a self) -> impl Iterator<Item = VarLabel> + 'a {
+    pub fn reverse_in_order_iter(&self) -> impl Iterator<Item = VarLabel> + '_ {
         self.pos_to_var
             .iter()
             .map(|x| VarLabel::new_usize(*x))
@@ -189,11 +189,11 @@ impl VarOrder {
     }
 
     /// Returns an iterator of all variables between [low_level..high_level)
-    pub fn between_iter<'a>(
-        &'a self,
+    pub fn between_iter(
+        &self,
         low_level: usize,
         high_level: usize,
-    ) -> impl Iterator<Item = VarLabel> + 'a {
+    ) -> impl Iterator<Item = VarLabel> + '_ {
         assert!(low_level <= high_level);
         self.pos_to_var
             .iter()
@@ -209,7 +209,7 @@ fn var_order_basics() {
     let order = VarOrder::linear_order(10);
     let lbl1 = VarLabel::new(4);
     let lbl2 = VarLabel::new(5);
-    assert_eq!(order.lt(lbl1, lbl2), true);
-    assert_eq!(order.lt(lbl2, lbl1), false);
+    assert!(order.lt(lbl1, lbl2));
+    assert!(!order.lt(lbl2, lbl1));
     assert_eq!(order.above(lbl2).unwrap(), lbl1);
 }

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -47,7 +47,7 @@ impl VTree {
     /// generate an even vtree by splitting a variable ordering in half repeatedly
     /// times; then reverts to a right-linear vtree for the remainder
     pub fn even_split(order: &[VarLabel], num_splits: usize) -> VTree {
-        if num_splits <= 0 {
+        if num_splits == 0 {
             Self::right_linear(order)
         } else {
             let (l_s, r_s) = order.split_at(order.len() / 2);
@@ -112,6 +112,7 @@ pub struct VTreeManager {
     bfs_to_dfs: Vec<usize>,
     /// maps an Sdd VarLabel into its vtree index in the depth-first order
     vtree_idx: Vec<usize>,
+    #[allow(clippy::vec_box)] // TODO: fix this, but requires some refactoring
     index_lookup: Vec<Box<VTree>>,
     lca: LeastCommonAncestor,
 }
@@ -150,7 +151,7 @@ impl VTreeManager {
 
     /// Given a vtree index, produce a pointer to the vtree this corresponds with
     pub fn get_idx(&self, idx: VTreeIndex) -> &VTree {
-        &*(self.index_lookup[idx.0])
+        &(self.index_lookup[idx.0])
     }
 
     /// Find the index into self.vtree that contains the label `lbl`

--- a/src/sample/probability.rs
+++ b/src/sample/probability.rs
@@ -24,7 +24,7 @@ impl std::ops::Add<Probability> for Probability {
 impl std::ops::Sub<Probability> for Probability {
     type Output = Probability;
     fn sub(self, rhs: Probability) -> Probability {
-        Probability::new(self.0 + rhs.0)
+        Probability::new(self.0 - rhs.0)
     }
 }
 
@@ -38,6 +38,6 @@ impl std::ops::Mul<Probability> for Probability {
 impl std::ops::Div<Probability> for Probability {
     type Output = Probability;
     fn div(self, rhs: Probability) -> Probability {
-        Probability::new(self.0 * rhs.0)
+        Probability::new(self.0 / rhs.0)
     }
 }

--- a/src/util/hypergraph.rs
+++ b/src/util/hypergraph.rs
@@ -1,5 +1,12 @@
 // TODO: remove crate-level disable
 #![allow(unused_imports)]
+#![allow(
+    clippy::ptr_arg,
+    clippy::type_complexity,
+    clippy::clone_on_copy,
+    clippy::redundant_clone,
+    clippy::explicit_counter_loop
+)]
 
 use crate::repr::cnf::Cnf;
 use crate::repr::var_label::{Literal, VarLabel};
@@ -50,7 +57,7 @@ impl<T: Clone + Debug + PartialEq + Eq + Hash> Hypergraph<T> {
         &self.vertices
     }
     pub fn edges(&self) -> Vec<&HashSet<T>> {
-        self.hyperedges.iter().filter(|hs| hs.len() > 0).collect()
+        self.hyperedges.iter().filter(|hs| !hs.is_empty()).collect()
     }
     pub fn edges_for(&self, node: &T) -> Option<Vec<&HashSet<T>>> {
         let cache = Self::cache_from(&self.vertices, &self.hyperedges);
@@ -71,11 +78,11 @@ impl<T: Clone + Debug + PartialEq + Eq + Hash> Hypergraph<T> {
             let os: Vec<(usize, (HashSet<T>, Vec<&HashSet<T>>))> = overlaps
                 .iter()
                 .enumerate()
-                .filter(|(_, o)| !o.0.is_disjoint(&e))
+                .filter(|(_, o)| !o.0.is_disjoint(e))
                 .map(|(i, (l, r))| (i, (l.clone(), r.clone())))
                 .collect();
 
-            if os.len() == 0 {
+            if os.is_empty() {
                 overlaps.push((e.clone(), vec![e]))
             } else {
                 let mut newc = e.clone();
@@ -93,7 +100,7 @@ impl<T: Clone + Debug + PartialEq + Eq + Hash> Hypergraph<T> {
                 }
                 overlaps.push((
                     newc,
-                    dedupe_hashset_refs(newes.into_iter().filter(|s| s.len() > 0).collect()),
+                    dedupe_hashset_refs(newes.into_iter().filter(|s| !s.is_empty()).collect()),
                 ));
             }
         }
@@ -138,7 +145,7 @@ impl<T: Clone + Debug + PartialEq + Eq + Hash> Hypergraph<T> {
     /// add an edge to the hypergraph. Returns false if the edge is already in the hypergraph
     pub fn insert_edge(&mut self, edge: &HashSet<T>) -> bool {
         let new_verts: HashSet<T> = edge.difference(&self.vertices).cloned().collect();
-        if new_verts.len() > 0 {
+        if !new_verts.is_empty() {
             let vertices = self.vertices().union(&new_verts).cloned().collect();
             self.vertices = vertices;
         }
@@ -164,7 +171,7 @@ impl<T: Clone + Debug + PartialEq + Eq + Hash> Hypergraph<T> {
             }
             let new_edges = dedupe_hashsets(self.hyperedges.clone())
                 .into_iter()
-                .filter(|s| s.len() > 0)
+                .filter(|s| !s.is_empty())
                 .collect();
             self.hyperedges = new_edges;
             // self.assoc_cache.remove(v);
@@ -177,7 +184,7 @@ impl<T: Clone + Debug + PartialEq + Eq + Hash> Hypergraph<T> {
             let contains_part1 = part1.iter().any(|i| e.contains(i));
             let contains_part2 = part2.iter().any(|i| e.contains(i));
             if contains_part1 && contains_part2 {
-                r = r + 1;
+                r += 1;
             }
         }
         r
@@ -224,7 +231,7 @@ fn dedupe_hashset_refs<T: Hash + Eq>(hss: Vec<&HashSet<T>>) -> Vec<&HashSet<T>> 
             Some(cached_hss) => {
                 let mut add = true;
                 for hs in cached_hss.iter() {
-                    if hs.symmetric_difference(&cur).next().is_none() {
+                    if hs.symmetric_difference(cur).next().is_none() {
                         add = false;
                         break;
                     }
@@ -461,7 +468,7 @@ mod test {
             let mut order: Vec<(u64, f64)> = vec![];
             for v in g.vertices() {
                 let mut tmp = g.clone();
-                tmp.cut_vertex(&v);
+                tmp.cut_vertex(v);
                 // naive take 1
                 let _mx_width: f64 = tmp.widths().1 as f64;
                 // naive take 2
@@ -478,7 +485,7 @@ mod test {
                 let (new_num_edges, total_acc) =
                     g.edges().iter().fold((0_f64, 0_f64), |(count, acc), e| {
                         let l = e.len() as f64;
-                        if e.contains(&v) {
+                        if e.contains(v) {
                             if l - 1.0 > 0.0 {
                                 (count + 1.0, acc + 2_f64.powf(l - 1.0))
                             } else {
@@ -496,14 +503,14 @@ mod test {
                     .iter()
                     .flat_map(|(cover, es)| {
                         let l = cover.len() as f64;
-                        if !cover.contains(&v) {
+                        if !cover.contains(v) {
                             vec![l]
                         } else {
                             let newes: Vec<HashSet<u64>> = es
                                 .iter()
                                 .cloned()
                                 .map(|e| e.difference(&HashSet::from([*v])).cloned().collect())
-                                .filter(|e: &HashSet<u64>| e.len() > 0)
+                                .filter(|e: &HashSet<u64>| !e.is_empty())
                                 .collect();
                             let cs = Hypergraph::edges_to_covers(newes.clone().iter().collect())
                                 .iter()

--- a/src/util/lru.rs
+++ b/src/util/lru.rs
@@ -27,6 +27,12 @@ impl ApplyCacheStats {
     }
 }
 
+impl Default for ApplyCacheStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// cap `v` at 2^`p`
 #[inline]
 fn pow_cap(v: usize, p: usize) -> usize {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -36,13 +36,14 @@ pub fn zero_vec<T>(sz: usize) -> Vec<T> {
     let mut v: Vec<T> = Vec::with_capacity(sz);
     unsafe {
         let vec_ptr = v.as_mut_ptr();
-        ptr::write_bytes(vec_ptr, 0, sz as usize);
+        ptr::write_bytes(vec_ptr, 0, sz);
         v.set_len(sz);
     }
     v
 }
 
 /// custom allocation of a non-initialized vector
+#[allow(clippy::uninit_vec)] // intentionally unsafe code
 pub fn malloc_vec<T>(sz: usize) -> Vec<T> {
     let mut v: Vec<T> = Vec::with_capacity(sz);
     unsafe {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -369,8 +369,8 @@ mod test_bdd_manager {
             let and = mgr.or(clause1, clause2);
 
             if and != iff1 {
-                println!("cnf1: {}", c1.to_string());
-                println!("cnf2: {}", c2.to_string());
+                println!("cnf1: {}", c1);
+                println!("cnf2: {}", c2);
                 println!("not equal: Bdd1: {}, Bdd2: {}", and.to_string_debug(), iff1.to_string_debug());
             }
             TestResult::from_bool(and == iff1)
@@ -477,7 +477,7 @@ mod test_bdd_manager {
             let eps = f64::abs(bddres - dnnfres) < 0.0001;
             if !eps {
               println!("error on input {}: bddres {}, cnfres {}\n topdown bdd: {}\nbottom-up bdd: {}",
-                c1.to_string(), bddres, dnnfres, dnnf.to_string_debug(), cnf1.to_string_debug());
+                c1, bddres, dnnfres, dnnf.to_string_debug(), cnf1.to_string_debug());
             }
             TestResult::from_bool(eps)
         }
@@ -536,7 +536,7 @@ mod test_bdd_manager {
                 }
             }
             if f64::abs(max - marg_prob) > 0.00001 {
-                println!("cnf: {}", c1.to_string());
+                println!("cnf: {}", c1);
                 println!("true map probability: {max}\nGot map probability: {marg_prob} with assignment {:?}", _marg_assgn);
             }
             TestResult::from_bool(f64::abs(max - marg_prob) < 0.00001)
@@ -641,7 +641,7 @@ mod test_sdd_manager {
             let bdd_res = cnf_bdd.wmc(bddmgr.get_order(), &sdd_wmc);
 
             if f64::abs(sdd_res - bdd_res) > 0.00001 {
-                println!("not equal for cnf {}: sdd_res:{sdd_res}, bdd_res: {bdd_res}", cnf.to_string());
+                println!("not equal for cnf {}: sdd_res:{sdd_res}, bdd_res: {bdd_res}", cnf);
                 println!("sdd: {}", mgr.print_sdd(cnf_sdd));
                 TestResult::from_bool(false)
             } else {


### PR DESCRIPTION
This PR's main goal is to have `cargo clippy` flag nothing! This means:

- when we add new code, it'll be very obvious when new errors are introduced
- we can run `clippy` on CI!

This PR touches *a ton* of code. I didn't want to break anything, so I manually inspected each `clippy` warning. The methodology was:

- if the fix is trivial / a no-op, implement it
- if the fix is syntactic sugar, implement it
- if the fix requires "minor" refactoring only local to that code (ex early return in an if statement), implement it
- if the fix requires anything more than a few lines of code, instead `#[allow]` the warning and put a TODO
    - the only exception to this was warnings that wanted me to implement a new trait (ex `Display`, `Default`) for an existing class. I did these, since it's pretty straightforward.
- in the rare cases that the behaviour is intended (ex intentional `mut` pointers, intentional unsafe code) I've added an `#allow` with no TODO

Test behaviour is still the same, and I'm relatively confident that this should not break any code.