### PR TITLE
Fix bugs in probabilistic equivalence check, add quickcheck regression tests

### DIFF
--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -606,7 +606,7 @@ impl SddManager {
                 let h = helper(_man, ptr.high());
                 let mut doc: Doc<BoxDoc> = Doc::from("");
                 doc = doc.append(Doc::newline()).append(
-                    (Doc::from(format!("ITE {:?} ", ptr))
+                    (Doc::from(format!("ITE {:?} {}", ptr, ptr.topvar().value()))
                         .append(Doc::newline())
                         .append(h.append(Doc::newline()).append(l)))
                     .nest(2),
@@ -628,7 +628,7 @@ impl SddManager {
                     .nest(2),
                 );
             }
-            let d = Doc::from("\\/".to_string());
+            let d = Doc::from(format!("\\/ {:?}", ptr));
             d.append(doc.nest(2))
         }
         let d = helper(self, ptr);
@@ -781,7 +781,7 @@ impl SddManager {
         let mut random_order = vars;
         random_order.shuffle(&mut thread_rng());
 
-        let mut value_range: Vec<u128> = (2..prime).collect();
+        let mut value_range: Vec<u128> = (2..prime / 2).collect();
         value_range.shuffle(&mut thread_rng());
 
         let mut map = HashMap::<usize, u128>::new();

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -506,40 +506,51 @@ impl SddPtr {
             }
         }
     }
-
     // heavy lifting for getting the semantic hash of SDD; assumes current is the root
     // this function doesn't allocate anything!
     // for more info, see https://tr.inf.unibe.ch/pdf/iam-06-001.pdf
     pub fn get_semantic_hash(&self, map: &HashMap<usize, u128>, prime: u128) -> u128 {
+        fn get_var_weight(
+            v: &VarLabel,
+            polarity: bool,
+            map: &HashMap<usize, u128>,
+            prime: u128,
+        ) -> u128 {
+            match map.get(&v.value_usize()) {
+                None => panic!("error - variable weight not defined in map"),
+                Some(&val) => {
+                    if polarity {
+                        return val;
+                    }
+                    prime - val + 1
+                }
+            }
+        }
+
         match &self {
             PtrTrue => 1,
             PtrFalse => 0,
-            Var(v, polarity) => match map.get(&v.value_usize()) {
-                None => panic!("error!"),
-                Some(val) => {
-                    if *polarity {
-                        *val
-                    } else {
-                        (prime - *val) + 1
-                    }
-                }
-            },
-            BDD(_) | ComplBDD(_) => {
-                (self.low().get_semantic_hash(map, prime)
-                    + self.high().get_semantic_hash(map, prime))
-                    % prime
+            Var(v, polarity) => get_var_weight(v, *polarity, map, prime),
+            BDD(_) => {
+                let label_weight = get_var_weight(&self.topvar(), true, map, prime);
+
+                let low_weight = self.low().get_semantic_hash(map, prime);
+                let high_weight = self.high().get_semantic_hash(map, prime);
+
+                ((prime - label_weight + 1) * low_weight + label_weight * high_weight) % prime
             }
-            // TODO: do I need to flip Compl here somehow?
-            Reg(_) | Compl(_) => {
+            Reg(_) => {
                 let raw_hash: u128 = self
                     .node_iter()
                     .map(|and| {
                         and.prime().get_semantic_hash(map, prime)
-                            + and.sub().get_semantic_hash(map, prime)
+                            * and.sub().get_semantic_hash(map, prime)
                     })
                     .sum();
                 raw_hash % prime
             }
+
+            ComplBDD(_) | Compl(_) => prime - self.to_reg().get_semantic_hash(map, prime) + 1,
         }
     }
 }

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -510,34 +510,31 @@ impl SddPtr {
     // this function doesn't allocate anything!
     // for more info, see https://tr.inf.unibe.ch/pdf/iam-06-001.pdf
     pub fn get_semantic_hash(&self, map: &HashMap<usize, u128>, prime: u128) -> u128 {
-        fn get_var_weight(
-            v: &VarLabel,
-            polarity: bool,
-            map: &HashMap<usize, u128>,
-            prime: u128,
-        ) -> u128 {
+        let negate_hash = |val: u128| -> u128 { (prime - val + 1) % prime };
+
+        let get_var_weight = |v: &VarLabel, polarity: bool| -> u128 {
             match map.get(&v.value_usize()) {
                 None => panic!("error - variable weight not defined in map"),
                 Some(&val) => {
                     if polarity {
                         return val;
                     }
-                    (prime - val + 1) % prime
+                    negate_hash(val)
                 }
             }
-        }
+        };
 
         match &self {
             PtrTrue => 1,
             PtrFalse => 0,
-            Var(v, polarity) => get_var_weight(v, *polarity, map, prime),
+            Var(v, polarity) => get_var_weight(v, *polarity),
             BDD(_) => {
-                let label_weight = get_var_weight(&self.topvar(), true, map, prime);
+                let label_weight = get_var_weight(&self.topvar(), true);
 
                 let low_weight = self.low().get_semantic_hash(map, prime);
                 let high_weight = self.high().get_semantic_hash(map, prime);
 
-                ((prime - label_weight + 1) * low_weight + label_weight * high_weight) % prime
+                (negate_hash(label_weight) * low_weight + label_weight * high_weight) % prime
             }
             Reg(_) => {
                 let raw_hash: u128 = self
@@ -550,9 +547,7 @@ impl SddPtr {
                 raw_hash % prime
             }
 
-            ComplBDD(_) | Compl(_) => {
-                (prime - self.to_reg().get_semantic_hash(map, prime) + 1) % prime
-            }
+            ComplBDD(_) | Compl(_) => negate_hash(self.to_reg().get_semantic_hash(map, prime)),
         }
     }
 }

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -522,7 +522,7 @@ impl SddPtr {
                     if polarity {
                         return val;
                     }
-                    prime - val + 1
+                    (prime - val + 1) % prime
                 }
             }
         }
@@ -550,7 +550,9 @@ impl SddPtr {
                 raw_hash % prime
             }
 
-            ComplBDD(_) | Compl(_) => prime - self.to_reg().get_semantic_hash(map, prime) + 1,
+            ComplBDD(_) | Compl(_) => {
+                (prime - self.to_reg().get_semantic_hash(map, prime) + 1) % prime
+            }
         }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -755,4 +755,36 @@ mod test_sdd_manager {
             }
         }
     }
+
+    quickcheck! {
+        fn prob_equiv_sdd_inequality(c1: Cnf, c2: Cnf, vtree:VTree) -> TestResult {
+            if c1.num_vars() > 4 || c1.clauses().len() > 4 || c2.num_vars() > 4 || c2.clauses().len() > 4 {
+                return TestResult::discard();
+            }
+
+            let mut mgr = super::SddManager::new(vtree);
+            let cnf_1 = mgr.from_cnf(&c1);
+            let cnf_2 = mgr.from_cnf(&c2);
+
+            if cnf_1 == cnf_2 {
+                return TestResult::discard();
+            }
+
+            let prime = 1123; // large enough for our purposes
+            let map = mgr.create_prob_map(prime);
+
+            let h1 = cnf_1.get_semantic_hash(&map, prime);
+            let h2 = cnf_2.get_semantic_hash(&map, prime);
+
+            if h1 == h2 {
+                println!("unintended equality! h1: {h1}, h2: {h2}");
+                println!("map: {:?}", map);
+                println!("sdd1: {}", mgr.print_sdd(cnf_1));
+                println!("sdd2: {}", mgr.print_sdd(cnf_2));
+                TestResult::from_bool(false)
+            } else {
+                TestResult::from_bool(true)
+            }
+        }
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -687,26 +687,6 @@ mod test_sdd_manager {
         }
     }
 
-    // quickcheck! {
-    //     fn sdd_prob_equiv_identical_test(c: Cnf, vtree: VTree) -> bool {
-    //         let mut compr_mgr = super::SddManager::new(vtree.clone());
-    //         let compr_cnf = compr_mgr.from_cnf(&c);
-
-    //         let mut uncompr_mgr = super::SddManager::new(vtree);
-    //         uncompr_mgr.set_compression(false);
-    //         let uncompr_cnf = uncompr_mgr.from_cnf(&c);
-
-    //         // let prime = 64733603481794218985640164159;
-    //         let prime = 1123;
-    //         let map = uncompr_mgr.create_prob_map(prime);
-
-    //         let compr_h = compr_cnf.get_semantic_hash(&map, prime);
-    //         let uncompr_h = uncompr_cnf.get_semantic_hash(&map, prime);
-
-    //         compr_h == uncompr_h
-    //     }
-    // }
-
     quickcheck! {
         fn prob_equiv_trivial(c: Cnf, vtree:VTree) -> bool {
             let mut mgr1 = super::SddManager::new(vtree.clone());
@@ -727,10 +707,6 @@ mod test_sdd_manager {
 
     quickcheck! {
         fn prob_equiv_sdd_identity_uncompressed(c: Cnf, vtree:VTree) -> TestResult {
-            if c.num_vars() > 4 || c.clauses().len() > 4 {
-                return TestResult::discard();
-            }
-
             let mut compr_mgr = super::SddManager::new(vtree.clone());
             let compr_cnf = compr_mgr.from_cnf(&c);
 
@@ -758,10 +734,6 @@ mod test_sdd_manager {
 
     quickcheck! {
         fn prob_equiv_sdd_inequality(c1: Cnf, c2: Cnf, vtree:VTree) -> TestResult {
-            if c1.num_vars() > 4 || c1.clauses().len() > 4 || c2.num_vars() > 4 || c2.clauses().len() > 4 {
-                return TestResult::discard();
-            }
-
             let mut mgr = super::SddManager::new(vtree);
             let cnf_1 = mgr.from_cnf(&c1);
             let cnf_2 = mgr.from_cnf(&c2);
@@ -777,7 +749,7 @@ mod test_sdd_manager {
             let h2 = cnf_2.get_semantic_hash(&map, prime);
 
             if h1 == h2 {
-                println!("unintended equality! h1: {h1}, h2: {h2}");
+                println!("collision! h1: {h1}, h2: {h2}");
                 println!("map: {:?}", map);
                 println!("sdd1: {}", mgr.print_sdd(cnf_1));
                 println!("sdd2: {}", mgr.print_sdd(cnf_2));


### PR DESCRIPTION
This PR:

- fixes a few bugs in the probablistic equivalence check introduced in #46 
- adds quickcheck tests for:
    - verifying that a compressed and uncompressed version of the same SDD have the same hash code
    - verifying that two (compressed/canonical) syntactically different SDDs have different hash codes
- adds a bit more debugging information to the SDD manager's print SDD function 