### PR TITLE
Simplify `create_prob_map`

### DIFF
--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -781,7 +781,7 @@ impl SddManager {
         let rng = &mut thread_rng();
 
         let value_range: Vec<u128> = (0..vars.len() as u128)
-            .map(|_| rng.gen::<u128>() % prime)
+            .map(|_| rng.gen_range(2..prime))
             .collect();
 
         let mut map = HashMap::<usize, u128>::new();

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -4,7 +4,6 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 
 use super::cache::all_app::AllTable;
@@ -780,17 +779,14 @@ impl SddManager {
         assert!((2 * vars.len() as u128) < prime);
 
         let rng = &mut thread_rng();
-        let mut random_order = vars;
-        random_order.shuffle(rng);
 
-        let mut value_range: Vec<u128> = (2..(random_order.len() + 2) as u128)
+        let value_range: Vec<u128> = (0..vars.len() as u128)
             .map(|_| rng.gen::<u128>() % prime)
             .collect();
-        value_range.shuffle(&mut thread_rng());
 
         let mut map = HashMap::<usize, u128>::new();
 
-        for (&var, &value) in random_order.iter().zip(value_range.iter()) {
+        for (&var, &value) in vars.iter().zip(value_range.iter()) {
             map.insert(var, value);
         }
 


### PR DESCRIPTION
Three quick things:

- removes the now-unnecessary shuffles, since we're sampling from the range
- uses `gen_range` to generate numbers in the half-open `[2, prime)`, to avoid assigning `0` or `1` to a literal
- make the iterate range clearer

~~Before merging: https://github.com/pmall-neu/rsdd/commit/4d0c12cb81b1a4c520c34a054cd52dfa7b4a8dcc means that we can now assign `0` or `1` as valid weights for a literal; this is low-hanging fruit that we can probably resolve?~~=