### PR TITLE
Add semantic hash benchmark; fix minor bugs

### DIFF
--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -23,7 +23,6 @@ struct Args {
 
 fn run_canonicalizer_experiment(c: Cnf, vtree: VTree) {
     let start = Instant::now();
-    // print!("compressed... ");
 
     let mut compr_mgr = SddManager::<CompressionCanonicalizer>::new(vtree.clone());
     let compr_cnf = compr_mgr.from_cnf(&c);
@@ -43,18 +42,15 @@ fn run_canonicalizer_experiment(c: Cnf, vtree: VTree) {
     );
 
     let start = Instant::now();
-    // print!("semantic... ");
 
+    // TODO: make the prime a CLI arg / iterable?
     // 18,446,744,073,709,551,616 - 25
-    // TODO: make the prime a CLI arg
-    let mut sem_mgr = SddManager::<SemanticCanonicalizer<18_446_744_073_709_551_591>>::new(vtree);
-    // let mut sem_mgr = SddManager::<SemanticCanonicalizer<479001599>>::new(vtree);
+    // let mut sem_mgr = SddManager::<SemanticCanonicalizer<18_446_744_073_709_551_591>>::new(vtree);
     // let mut sem_mgr = SddManager::<SemanticCanonicalizer<100000049>>::new(vtree);
+    let mut sem_mgr = SddManager::<SemanticCanonicalizer<479001599>>::new(vtree);
     let sem_cnf = sem_mgr.from_cnf(&c);
-    // saving this before we run sdd_eq, which could add nodes to the table
 
     let duration = start.elapsed();
-    // println!("time: {:?}", duration);
 
     let stats = sem_mgr.get_stats();
     println!(
@@ -69,9 +65,7 @@ fn run_canonicalizer_experiment(c: Cnf, vtree: VTree) {
     println!("c time: {:?}", cduration);
     println!("s time: {:?}", duration);
     println!(" ");
-    // print!("compr sdd: ");
-    // sem_mgr.dump_sdd_state(compr_cnf);
-    // print!("h: ");
+
     sem_mgr.dump_sdd_state(sem_cnf);
     if !sem_mgr.sdd_eq(compr_cnf, sem_cnf) {
         println!(" ");
@@ -102,7 +96,7 @@ fn main() {
 
     // let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
     // let vtree = VTree::from_dtree(&dtree).unwrap();
-    let vtree = VTree::even_split(vars, 1);
+    let vtree = VTree::even_split(vars, 2);
 
     run_canonicalizer_experiment(cnf, vtree);
 }

--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -16,71 +16,71 @@ use std::time::Instant;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// An input Bayesian network file in JSON format
+    /// An input CNF
     #[clap(short, long, value_parser)]
     file: String,
 }
 
 fn run_canonicalizer_experiment(c: Cnf, vtree: VTree) {
     let start = Instant::now();
-    println!("creating uncompressed...");
-
-    let mut uncompr_mgr = SddManager::<CompressionCanonicalizer>::new(vtree.clone());
-    uncompr_mgr.set_compression(false);
-    let uncompr_cnf = uncompr_mgr.from_cnf(&c);
-
-    let duration = start.elapsed();
-    println!("time: {:?}", duration);
-
-    let start = Instant::now();
-    println!("creating compressed...");
+    // print!("compressed... ");
 
     let mut compr_mgr = SddManager::<CompressionCanonicalizer>::new(vtree.clone());
     let compr_cnf = compr_mgr.from_cnf(&c);
 
-    let duration = start.elapsed();
-    println!("time: {:?}", duration);
+    let cduration = start.elapsed();
+    println!(" ");
+
+    let stats = compr_mgr.get_stats();
+    println!(
+        "c: {:05} nodes | {:06} uniq | {:07} rec | {} g/i | {}/{} compr/and",
+        compr_cnf.num_nodes(),
+        compr_mgr.canonicalizer().bdd_num_uniq() + compr_mgr.canonicalizer().sdd_num_uniq(),
+        stats.num_rec,
+        stats.num_get_or_insert,
+        stats.num_compr,
+        stats.num_compr_and,
+    );
 
     let start = Instant::now();
-    println!("creating semantic...");
+    // print!("semantic... ");
 
     // 18,446,744,073,709,551,616 - 25
     // TODO: make the prime a CLI arg
     let mut sem_mgr = SddManager::<SemanticCanonicalizer<18_446_744_073_709_551_591>>::new(vtree);
+    // let mut sem_mgr = SddManager::<SemanticCanonicalizer<479001599>>::new(vtree);
+    // let mut sem_mgr = SddManager::<SemanticCanonicalizer<100000049>>::new(vtree);
     let sem_cnf = sem_mgr.from_cnf(&c);
     // saving this before we run sdd_eq, which could add nodes to the table
-    let sem_uniq = sem_mgr.canonicalizer().bdd_num_uniq() + sem_mgr.canonicalizer().sdd_num_uniq();
 
     let duration = start.elapsed();
-    println!("time: {:?}", duration);
+    // println!("time: {:?}", duration);
 
-    if !sem_mgr.sdd_eq(uncompr_cnf, sem_cnf) {
-        println!("not equal! not continuing with test...");
-        println!("uncompr sdd: {}", sem_mgr.print_sdd(uncompr_cnf));
-        println!("sem sdd: {}", sem_mgr.print_sdd(sem_cnf));
-        return;
-    }
+    let stats = sem_mgr.get_stats();
+    println!(
+        "s: {:05} nodes | {:06} uniq | {:07} rec | {} g/i",
+        sem_cnf.num_nodes(),
+        sem_mgr.canonicalizer().bdd_num_uniq() + sem_mgr.canonicalizer().sdd_num_uniq(),
+        stats.num_rec,
+        stats.num_get_or_insert,
+    );
 
+    println!(" ");
+    println!("c time: {:?}", cduration);
+    println!("s time: {:?}", duration);
+    println!(" ");
+    // print!("compr sdd: ");
+    // sem_mgr.dump_sdd_state(compr_cnf);
+    // print!("h: ");
+    sem_mgr.dump_sdd_state(sem_cnf);
     if !sem_mgr.sdd_eq(compr_cnf, sem_cnf) {
-        println!("not equal! not continuing with test...");
-        println!("compr sdd: {}", sem_mgr.print_sdd(compr_cnf));
-        println!("sem sdd: {}", sem_mgr.print_sdd(sem_cnf));
-        return;
+        println!(" ");
+        println!("not equal! test is broken...");
+        eprintln!("=== COMPRESSED CNF ===");
+        eprintln!("{}", sem_mgr.print_sdd(compr_cnf));
+        eprintln!("=== SEMANTIC CNF ===");
+        eprintln!("{}", sem_mgr.print_sdd(sem_cnf));
     }
-
-    println!(
-        "uncompr: {} nodes, {} uniq",
-        uncompr_cnf.num_nodes(),
-        uncompr_mgr.canonicalizer().bdd_num_uniq() + uncompr_mgr.canonicalizer().sdd_num_uniq()
-    );
-
-    println!(
-        "compr: {} nodes, {} uniq",
-        compr_cnf.num_nodes(),
-        compr_mgr.canonicalizer().bdd_num_uniq() + compr_mgr.canonicalizer().sdd_num_uniq()
-    );
-
-    println!("sem: {} nodes, {} uniq", sem_cnf.num_nodes(), sem_uniq);
 }
 
 fn main() {
@@ -89,7 +89,7 @@ fn main() {
     let cnf_input = fs::read_to_string(args.file).expect("Should have been able to read the file");
 
     let cnf = Cnf::from_file(cnf_input);
-    println!("{}", cnf.num_vars());
+    println!("num vars: {}", cnf.num_vars());
 
     let range: Vec<usize> = (0..cnf.num_vars() + 1).collect();
     let binding = range
@@ -98,7 +98,11 @@ fn main() {
         .collect::<Vec<VarLabel>>();
     let vars = binding.as_slice();
 
-    let vtree = VTree::right_linear(vars);
+    // let vtree = VTree::right_linear(vars);
+
+    // let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
+    // let vtree = VTree::from_dtree(&dtree).unwrap();
+    let vtree = VTree::even_split(vars, 1);
 
     run_canonicalizer_experiment(cnf, vtree);
 }

--- a/src/builder/cache/sdd_apply_cache.rs
+++ b/src/builder/cache/sdd_apply_cache.rs
@@ -42,7 +42,7 @@ impl Default for SddApplyCompression {
 }
 
 pub struct SddApplySemantic<const P: u128> {
-    table: FxHashMap<FiniteField<P>, SddPtr>,
+    table: FxHashMap<u128, SddPtr>,
     map: WmcParams<FiniteField<P>>,
     vtree: VTreeManager,
 }
@@ -60,10 +60,16 @@ impl<const P: u128> SddApplySemantic<P> {
 impl<const P: u128> SddApply for SddApplySemantic<P> {
     fn get(&self, and: SddAnd) -> Option<SddPtr> {
         let h = and.semantic_hash(&self.vtree, &self.map);
-        self.table.get(&h).copied()
+        match h.value() {
+            0 => Some(SddPtr::PtrFalse),
+            1 => Some(SddPtr::PtrTrue),
+            _ => self.table.get(&h.value()).copied(),
+        }
     }
     fn insert(&mut self, and: SddAnd, ptr: SddPtr) {
         let h = and.semantic_hash(&self.vtree, &self.map);
-        self.table.insert(h, ptr);
+        if h.value() > 1 {
+            self.table.insert(h.value(), ptr);
+        }
     }
 }

--- a/src/builder/canonicalize.rs
+++ b/src/builder/canonicalize.rs
@@ -125,16 +125,17 @@ impl<const P: u128> UniqueTableHasher<BinarySDD> for SemanticUniqueTableHasher<P
     // TODO(matt): we should be able to de-duplicate this with fold/wmc
     fn u64hash(&self, elem: &BinarySDD) -> u64 {
         let mut hasher = FxHasher::default();
-        // elem.hash(&mut hasher);
 
         let (low_w, high_w) = self.map.get_var_weight(elem.label());
 
+        // TODO(matt): investigate if this works properly!
         FiniteField::<P>::new(
             elem.low().semantic_hash(&self.vtree, &self.map).value() * low_w.value()
             // (P - elem.low().semantic_hash(&self.vtree, &self.map).value() + 1) * low_w.value()
                 + elem.high().semantic_hash(&self.vtree, &self.map).value() * high_w.value(),
         )
-        .value().hash(&mut hasher);
+        .value()
+        .hash(&mut hasher);
         hasher.finish()
     }
 }
@@ -149,7 +150,8 @@ impl<const P: u128> UniqueTableHasher<SddOr> for SemanticUniqueTableHasher<P> {
                 .map(|and| and.semantic_hash(&self.vtree, &self.map).value())
                 .fold(0, |accum, elem| accum + elem),
         )
-        .value().hash(&mut hasher);
+        .value()
+        .hash(&mut hasher);
         hasher.finish()
     }
 }
@@ -235,6 +237,5 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
 
     fn on_sdd_print_dump_state(&self, ptr: SddPtr) {
         println!("h: {}", ptr.semantic_hash(&self.vtree, &self.map),);
-        // self.map.dump_all_var_weights()
     }
 }

--- a/src/builder/canonicalize.rs
+++ b/src/builder/canonicalize.rs
@@ -1,3 +1,7 @@
+use std::hash::{Hash, Hasher};
+
+use rustc_hash::FxHasher;
+
 use super::bdd_builder::DDNNFPtr;
 use super::cache::sdd_apply_cache::{SddApply, SddApplyCompression, SddApplySemantic};
 use crate::backing_store::bump_table::BackedRobinhoodTable;
@@ -118,23 +122,35 @@ impl<const P: u128> SemanticUniqueTableHasher<P> {
 }
 
 impl<const P: u128> UniqueTableHasher<BinarySDD> for SemanticUniqueTableHasher<P> {
-    // TODO: we should be able to de-duplicate this with fold
+    // TODO(matt): we should be able to de-duplicate this with fold/wmc
     fn u64hash(&self, elem: &BinarySDD) -> u64 {
+        let mut hasher = FxHasher::default();
+        // elem.hash(&mut hasher);
+
         let (low_w, high_w) = self.map.get_var_weight(elem.label());
 
-        (((self.map.one - elem.low().semantic_hash(&self.vtree, &self.map)) * *low_w
-            + elem.high().semantic_hash(&self.vtree, &self.map) * *high_w)
-            .value()) as u64
+        FiniteField::<P>::new(
+            elem.low().semantic_hash(&self.vtree, &self.map).value() * low_w.value()
+            // (P - elem.low().semantic_hash(&self.vtree, &self.map).value() + 1) * low_w.value()
+                + elem.high().semantic_hash(&self.vtree, &self.map).value() * high_w.value(),
+        )
+        .value().hash(&mut hasher);
+        hasher.finish()
     }
 }
 
 impl<const P: u128> UniqueTableHasher<SddOr> for SemanticUniqueTableHasher<P> {
+    // TODO(matt): we should be able to de-duplicate this with fold/wmc
     fn u64hash(&self, elem: &SddOr) -> u64 {
-        elem.nodes
-            .iter()
-            .map(|and| and.semantic_hash(&self.vtree, &self.map))
-            .fold(FiniteField::new(0), |accum, elem| accum + elem)
-            .value() as u64
+        let mut hasher = FxHasher::default();
+        FiniteField::<P>::new(
+            elem.nodes
+                .iter()
+                .map(|and| and.semantic_hash(&self.vtree, &self.map).value())
+                .fold(0, |accum, elem| accum + elem),
+        )
+        .value().hash(&mut hasher);
+        hasher.finish()
     }
 }
 
@@ -218,6 +234,7 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
     }
 
     fn on_sdd_print_dump_state(&self, ptr: SddPtr) {
-        println!("h: {}", ptr.semantic_hash(&self.vtree, &self.map))
+        println!("h: {}", ptr.semantic_hash(&self.vtree, &self.map),);
+        // self.map.dump_all_var_weights()
     }
 }

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -153,7 +153,8 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
             self.unique_bdd(BinarySDD::new(v, low, high, table))
         } else {
             node.sort_by_key(|a| a.prime());
-            if node[0].sub().is_neg() || self.is_false(node[0].sub()) || node[0].sub().is_neg_var() {
+            if node[0].sub().is_neg() || self.is_false(node[0].sub()) || node[0].sub().is_neg_var()
+            {
                 for x in node.iter_mut() {
                     *x = SddAnd::new(x.prime(), x.sub().neg());
                 }
@@ -352,7 +353,7 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         // for a in r.node_iter() {
         //     let p = self.and(a.prime(), d);
         //     let s = if r.is_compl() { a.sub().neg() } else { a.sub() };
-        //     if p) {
+        //     if self.is_false(p) {
         //         continue;
         //     }
         //     v.push(SddAnd::new(p, s));

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -19,11 +19,22 @@ use crate::{repr::cnf::Cnf, repr::logical_expr::LogicalExpr, repr::var_label::Va
 pub struct SddStats {
     /// total number of recursive calls
     pub num_rec: usize,
+    /// total number of calls to compress
+    pub num_compr: usize,
+    /// total number of new SddAnds generated in compress
+    pub num_compr_and: usize,
+    /// total number of gets/inserts generated in compress
+    pub num_get_or_insert: usize,
 }
 
 impl SddStats {
     pub fn new() -> SddStats {
-        SddStats { num_rec: 0 }
+        SddStats {
+            num_rec: 0,
+            num_compr: 0,
+            num_compr_and: 0,
+            num_get_or_insert: 0,
+        }
     }
 }
 
@@ -77,11 +88,13 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         if !self.canonicalizer.should_compress() {
             panic!("compress called when disabled")
         }
+        self.stats.num_compr += 1;
         for i in 0..node.len() {
             // see if we can compress i
             let mut j = i + 1;
             while j < node.len() {
                 if self.sdd_eq(node[i].sub(), node[j].sub()) {
+                    self.stats.num_compr_and += 1;
                     // compress j into i and remove j from the node list
                     node[i] = SddAnd::new(self.or(node[i].prime(), node[j].prime()), node[i].sub());
                     node.swap_remove(j);
@@ -94,6 +107,7 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
 
     /// Normalizes and fetches a node from the store
     pub fn get_or_insert(&mut self, sdd: SddOr) -> SddPtr {
+        self.stats.num_get_or_insert += 1;
         let p = self.canonicalizer.sdd_get_or_insert(sdd);
         SddPtr::or(p)
     }
@@ -139,7 +153,7 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
             self.unique_bdd(BinarySDD::new(v, low, high, table))
         } else {
             node.sort_by_key(|a| a.prime());
-            if node[0].sub().is_neg() || node[0].sub().is_false() || node[0].sub().is_neg_var() {
+            if node[0].sub().is_neg() || self.is_false(node[0].sub()) || node[0].sub().is_neg_var() {
                 for x in node.iter_mut() {
                     *x = SddAnd::new(x.prime(), x.sub().neg());
                 }
@@ -154,15 +168,15 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         if bdd.high() == bdd.low() {
             return bdd.high();
         }
-        if bdd.high().is_false() && bdd.low().is_true() {
+        if self.is_false(bdd.high()) && self.is_true(bdd.low()) {
             return SddPtr::var(bdd.label(), false);
         }
-        if bdd.high().is_true() && bdd.low().is_false() {
+        if self.is_true(bdd.high()) && self.is_false(bdd.low()) {
             return SddPtr::var(bdd.label(), true);
         }
 
         // uniqify BDD
-        if bdd.high().is_neg() || bdd.high().is_false() || bdd.high().is_neg_var() {
+        if bdd.high().is_neg() || self.is_false(bdd.high()) || bdd.high().is_neg_var() {
             let neg_bdd =
                 BinarySDD::new(bdd.label(), bdd.low().neg(), bdd.high().neg(), bdd.vtree());
             SddPtr::bdd(self.canonicalizer.bdd_get_or_insert(neg_bdd)).neg()
@@ -177,19 +191,19 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
             return Some(SddPtr::true_ptr());
         }
         if node.len() == 1 {
-            if node[0].prime().is_true() {
+            if self.is_true(node[0].prime()) {
                 return Some(node[0].sub());
             }
 
             // TODO: Why is this only included after compression?
-            if node[0].sub().is_false() {
+            if self.is_false(node[0].sub()) {
                 return Some(SddPtr::false_ptr());
             }
         }
         if node.len() == 2 {
-            if node[0].sub().is_true() && node[1].sub().is_false() {
+            if self.is_true(node[0].sub()) && self.is_false(node[1].sub()) {
                 return Some(node[0].prime());
-            } else if node[0].sub().is_false() && node[1].sub().is_true() {
+            } else if self.is_false(node[0].sub()) && self.is_true(node[1].sub()) {
                 return Some(node[1].prime());
             }
         }
@@ -204,14 +218,15 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         }
 
         if self.canonicalizer.should_compress() {
-            self.compress(&mut node)
+            self.compress(&mut node);
+
+            // check for a base case after compression (compression can sometimes
+            // reduce node counts to a base case)
+            if let Some(sdd) = self.canonicalize_base_case(&node) {
+                return sdd;
+            }
         }
 
-        // check for a base case after compression (compression can sometimes
-        // reduce node counts to a base case)
-        if let Some(sdd) = self.canonicalize_base_case(&node) {
-            return sdd;
-        }
         self.unique_or(node, table)
     }
 
@@ -316,14 +331,14 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
                 let s2 = a2.sub();
                 let p = self.and(p1, p2);
                 // println!("(PRIME) result of {} && {}: {}", self.print_sdd(p1), self.print_sdd(p2), self.print_sdd(p));
-                if p.is_false() {
+                if self.is_false(p) {
                     continue;
                 }
                 let s = self.and(s1, s2);
                 // println!("(SUB) result of {} && {}: {}", self.print_sdd(s1), self.print_sdd(s2), self.print_sdd(s));
                 // check if one of the nodes is true; if it is, we can
                 // return a `true` SddPtr here, for trimming
-                if p.is_true() && s.is_true() {
+                if self.is_true(p) && self.is_true(s) {
                     let new_v = SddPtr::true_ptr();
                     return new_v;
                 }
@@ -337,7 +352,7 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         // for a in r.node_iter() {
         //     let p = self.and(a.prime(), d);
         //     let s = if r.is_compl() { a.sub().neg() } else { a.sub() };
-        //     if p.is_false() {
+        //     if p) {
         //         continue;
         //     }
         //     v.push(SddAnd::new(p, s));
@@ -389,13 +404,13 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
                 let s2 = a2.sub();
                 let s2 = if b.is_neg() { s2.neg() } else { s2 };
                 let p = self.and(p1, p2);
-                if p.is_false() {
+                if self.is_false(p) {
                     continue;
                 }
                 let s = self.and(s1, s2);
                 // check if one of the nodes is true; if it is, we can
                 // return a `true` SddPtr here, for trimming
-                if p.is_true() && s.is_true() {
+                if self.is_true(p) && self.is_true(s) {
                     let new_v = SddPtr::true_ptr();
                     return new_v;
                 }
@@ -418,10 +433,10 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         self.stats.num_rec += 1;
         // first, check for a base case
         match (a, b) {
-            (a, b) if a.is_true() => return b,
-            (a, b) if b.is_true() => return a,
-            (a, _) if a.is_false() => return SddPtr::false_ptr(),
-            (_, b) if b.is_false() => return SddPtr::false_ptr(),
+            (a, b) if self.is_true(a) => return b,
+            (a, b) if self.is_true(b) => return a,
+            (a, _) if self.is_false(a) => return SddPtr::false_ptr(),
+            (_, b) if self.is_false(b) => return SddPtr::false_ptr(),
             (a, b) if self.sdd_eq(a, b) => return a,
             (a, b) if self.sdd_eq(a, b.neg()) => return SddPtr::false_ptr(),
             _ => (),
@@ -438,14 +453,14 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
             (b, a)
         };
 
-        let av = self.get_vtree_idx(a);
-        let bv = self.get_vtree_idx(b);
-        let lca = self.vtree.lca(av, bv);
-
         // check if we have this application cached
         if let Some(x) = self.canonicalizer.app_cache().get(SddAnd::new(a, b)) {
             return x;
         }
+
+        let av = self.get_vtree_idx(a);
+        let bv = self.get_vtree_idx(b);
+        let lca = self.vtree.lca(av, bv);
 
         // now we determine the current iterator for primes and subs
         // consider the following example vtree:
@@ -521,11 +536,11 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
             let sub = a.sub();
             let newp = self.condition(prime, lbl, value);
             let sub = if f.is_neg() { sub.neg() } else { sub };
-            if newp.is_false() {
+            if self.is_false(newp) {
                 continue;
             };
             let news = self.condition(sub, lbl, value);
-            if newp.is_true() {
+            if self.is_true(newp) {
                 return news;
             }
             v.push(SddAnd::new(newp, news));
@@ -583,9 +598,9 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
     }
 
     fn print_sdd_internal(&self, ptr: SddPtr) -> String {
+        self.canonicalizer.on_sdd_print_dump_state(ptr);
         use pretty::*;
         // TODO: this lifetime might be wrong
-        self.canonicalizer.on_sdd_print_dump_state(ptr);
         fn helper(ptr: SddPtr) -> Doc<'static, BoxDoc<'static>> {
             if ptr.is_true() {
                 return Doc::from("T");
@@ -638,16 +653,20 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         self.print_sdd_internal(ptr)
     }
 
+    pub fn dump_sdd_state(&self, ptr: SddPtr) {
+        self.canonicalizer.on_sdd_print_dump_state(ptr)
+    }
+
     pub fn sdd_eq(&self, a: SddPtr, b: SddPtr) -> bool {
         self.canonicalizer.sdd_eq(a, b)
     }
 
     pub fn is_true(&self, a: SddPtr) -> bool {
-        a.is_true()
+        self.sdd_eq(a, SddPtr::PtrTrue)
     }
 
     pub fn is_false(&self, a: SddPtr) -> bool {
-        a.is_false()
+        self.sdd_eq(a, SddPtr::PtrFalse)
     }
 
     /// compile an SDD from an input CNF

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -17,7 +17,8 @@ pub fn create_semantic_hash_map<const P: u128>(num_vars: usize) -> WmcParams<Fin
 
     // seed the RNG deterministically for reproducible weights across
     // different calls to `create_semantic_hash_map`
-    let mut rng = ChaCha8Rng::seed_from_u64(101249);
+    // let mut rng = ChaCha8Rng::seed_from_u64(101249);
+    let mut rng = ChaCha8Rng::from_entropy();
 
     let value_range: Vec<(FiniteField<P>, FiniteField<P>)> = (0..vars.len() as u128)
         .map(|_| {

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -17,8 +17,8 @@ pub fn create_semantic_hash_map<const P: u128>(num_vars: usize) -> WmcParams<Fin
 
     // seed the RNG deterministically for reproducible weights across
     // different calls to `create_semantic_hash_map`
-    // let mut rng = ChaCha8Rng::seed_from_u64(101249);
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::seed_from_u64(101249);
+    // let mut rng = ChaCha8Rng::from_entropy();
 
     let value_range: Vec<(FiniteField<P>, FiniteField<P>)> = (0..vars.len() as u128)
         .map(|_| {

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -144,7 +144,7 @@ impl SddAnd {
     pub fn new(prime: SddPtr, sub: SddPtr) -> SddAnd {
         SddAnd { prime, sub }
     }
-    // TODO: we should be able to de-duplicate this with fold
+    // TODO(matt): we should be able to de-duplicate this with fold/wmc
     pub fn semantic_hash<const P: u128>(
         &self,
         vtree: &VTreeManager,

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -66,6 +66,15 @@ impl<T: Semiring + std::ops::Mul<Output = T> + std::ops::Add<Output = T>> WmcPar
     }
 
     pub fn get_var_weight(&self, label: VarLabel) -> &(T, T) {
+        // TODO(matt): write a better error message - attempting to get label
         return (self.var_to_val[label.value_usize()]).as_ref().unwrap();
+    }
+
+    pub fn dump_all_var_weights(&self) {
+        self.var_to_val.iter().for_each(|f| {
+            let (low, high) = f.unwrap();
+            print!("low: {:?}, high: {:?} | ", low, high)
+        });
+        println!(" ")
     }
 }

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -69,12 +69,4 @@ impl<T: Semiring + std::ops::Mul<Output = T> + std::ops::Add<Output = T>> WmcPar
         // TODO(matt): write a better error message - attempting to get label
         return (self.var_to_val[label.value_usize()]).as_ref().unwrap();
     }
-
-    pub fn dump_all_var_weights(&self) {
-        self.var_to_val.iter().for_each(|f| {
-            let (low, high) = f.unwrap();
-            print!("low: {:?}, high: {:?} | ", low, high)
-        });
-        println!(" ")
-    }
 }

--- a/src/util/semiring.rs
+++ b/src/util/semiring.rs
@@ -59,7 +59,7 @@ impl Semiring for RealSemiring {
 }
 
 /// a finite-field abstraction. The parameter `p` is the size of the field.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FiniteField<const P: u128> {
     v: u128,
 }
@@ -88,15 +88,6 @@ impl<const P: u128> ops::Add<FiniteField<P>> for FiniteField<P> {
 
     fn add(self, rhs: FiniteField<P>) -> Self::Output {
         FiniteField::new((self.v + rhs.v) % P)
-    }
-}
-
-// TODO: perhaps, remove this, since it's not a quality of a semiring
-impl<const P: u128> ops::Sub<FiniteField<P>> for FiniteField<P> {
-    type Output = FiniteField<P>;
-
-    fn sub(self, rhs: FiniteField<P>) -> Self::Output {
-        FiniteField::new((P + self.v - rhs.v) % P)
     }
 }
 


### PR DESCRIPTION
This PR has two primary goals:

1. develop a runnable benchmark comparing semantic hashing to compression-based canonicalization
2. resolve some bugs :)

## Runnable Benchmark

For the former, I've written `semantic_hash_experiment`. You can run it with an input CNF file (DIMACS form) like so:

```
$ cargo run --bin semantic_hash_experiment --release -- --file cnf/php-5-4.cnf
```

It outputs a test result to stdin, and quite a bit of debugging information if the two SDDs don't match. 

Here's what one output looks like:

```
num vars: 20
c: 00001 nodes | 005023 uniq | 0068160 rec | 667 g/i | 1435/5918 compr/and
s: 01024 nodes | 003411 uniq | 1257578 rec | 33666 g/i
c time: 10.831292ms
s time: 14.397390167s
h: 0
```

Where `c` and `s` refer to a compression-based canonicalizer and a semantic one. In this test case, semantic hashing has two orders of magnitude more recursive calls (and get/inserts), but allocates less unique nodes. See below for other types of test cases.

## Testing

On a laptop, there are still some interesting tests you can run locally.  All of these use Massimo Lauria's [cnfgen](https://github.com/MassimoLauria/cnfgen) tool to generate arbitrary cases.

**tl;dr: naive semantic hashing wins (in recursive calls and allocated nodes) in classes of random CNFs. As you scale the number of variables or the number of clauses, it tends to lose.**

### "fair" test case

Here, both versions win, depending on the CNF.

```
cnfgen randkcnf 4 20 30 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- 2> err.txt --file cnf/rand.cnf
``` 

### clear wins

In these two classes of random CNFs (`10` variables, so not large), semantic hashing empirically has always won. Here, that means it needs less recursive calls to `and` than a compression-based canonicalizer.

```
cnfgen randkcnf 4 10 50 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- 2> err.txt --file cnf/rand.cnf
``` 

```
cnfgen randkcnf 5 10 60 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- 2> err.txt --file cnf/rand.cnf
``` 

## Bugfixing

This PR also bundles in some bugfixes and future bugfixes (`TODO(matt)`) for different areas of the codebase. Here's a comprehensive list:

1. removes the unnecessary `Hash` property added to `FiniteField` in #56 
2. convert the ApplyCache to use the field value instead of the struct itself, and bail out early if the hash value is 0/1
3. removes the unnecessary subtraction property for the finite field (also introduced in #56)
4. fix the `SemanticUniqueTableHasher` to (`FxHash`) hash WMC results, instead of casting to a `u64`
5. moves loop operations out of the `FiniteField` abstraction, minimizing the number of new field elements created
6. convert all `.is_false` and `.is_true` checks in the SDD builder to refer to the canonicalization scheme. For compression, this is unchanged; for semantic, it now checks if the hash is `0` or `1`

## Next Steps

There's more benchmarking we can do:
- generate pathological vtrees, like a left-linear one
- better vary the prime
- generate CNFs from other problems

As well as general code quality / bugfixing improvement (the collision rate still *feels* too high to me).