### PR TITLE
Implement `VTree::left_linear`, use in semantic hash benchmark

### DIFF
--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -92,11 +92,11 @@ fn main() {
         .collect::<Vec<VarLabel>>();
     let vars = binding.as_slice();
 
-    // let vtree = VTree::right_linear(vars);
+    let vtree = VTree::left_linear(vars);
 
     // let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
     // let vtree = VTree::from_dtree(&dtree).unwrap();
-    let vtree = VTree::even_split(vars, 2);
+    // let vtree = VTree::even_split(vars, 2);
 
     run_canonicalizer_experiment(cnf, vtree);
 }

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -39,6 +39,19 @@ impl VTree {
         }
     }
 
+    /// produces a left-linear vtree with the variable order given by `order`
+    pub fn left_linear(order: &[VarLabel]) -> VTree {
+        match order {
+            [x] => BTree::Leaf(*x),
+            [cur, rest @ ..] => {
+                let l_tree = Self::left_linear(rest);
+                let r_tree = BTree::Leaf(*cur);
+                BTree::Node((), Box::new(l_tree), Box::new(r_tree))
+            }
+            [] => panic!("invalid right_linear on empty list"),
+        }
+    }
+
     /// produces a right-linear vtree with the variable order given by `order`
     pub fn right_linear(order: &[VarLabel]) -> VTree {
         match order {
@@ -49,6 +62,14 @@ impl VTree {
                 BTree::Node((), Box::new(l_tree), Box::new(r_tree))
             }
             [] => panic!("invalid right_linear on empty list"),
+        }
+    }
+
+    /// true if this vtree is a left-linear fragment
+    pub fn is_left_linear(&self) -> bool {
+        match &self {
+            BTree::Node((), _, r) => r.is_leaf(),
+            _ => false,
         }
     }
 


### PR DESCRIPTION
This PR:

- implements `VTree::left_linear` and the associated predicate
- writes a quick `quickcheck!` test to validate that the generator/predicate pair works properly
- use it in the semantic hash experiment

## benchmark thoughts

Left-linear is *so slow*! I can't run the benchmarks from #67 locally; I'll run some on the server in a moment.

Interestingly, consider

```
$ cnfgen randkcnf 3 6 20 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- 2> err.txt --file cnf/rand.cnf
num vars: 6
c: 00003 nodes | 000422 uniq | 0020791 rec | 1409 g/i | 2380/3081 compr/and
s: 00032 nodes | 000566 uniq | 0035425 rec | 1381 g/i
c time: 2.97275ms
s time: 200.627042ms
h: 156400995
```

versus

```
$ cnfgen randkcnf 3 7 20 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- 2> err.txt --file cnf/rand.cnf
num vars: 7
c: 00003 nodes | 000953 uniq | 0063249 rec | 4436 g/i | 6820/9417 compr/and
s: 00064 nodes | 001105 uniq | 0304646 rec | 3540 g/i
c time: 4.436125ms
s time: 18.737464459s
h: 242354000
```

Increasing the number of variables by `1` and fixing everything else increased the order of magnitude! In addition, we don't get the reduction in recursive calls we saw elsewhere; but, we do have less gets/inserts into the apply cache.