### PR TITLE
Dep bumps (`clap`, `num`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ rand = "0.8.5"
 dimacs = "0.2.0"
 primal = "0.3.0"
 pretty = "0.3.3"
-num = "0.1.41"
+num = "0.4.0"
 maplit = "1.0.1"
 libc = "0.2"
 quickcheck = "1.0.3"
 time-test = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
-clap = { version = "3.2.14", features = ["derive"] }
+clap = { version = "4.2.1", features = ["derive"] }
 criterion = "0.3"
 rayon = "1.5.3"
 rustc-hash = "1.1.0"


### PR DESCRIPTION
Major dep bump for `clap` (but no breaking changes for us); `num` minor bump (that stops using `rustc-serializer`).

We should definitely eventually commit a lockfile.