### PR TITLE
Add `serde-wasm-bindgen`, allow VTree type as input parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rsgm = { git = "https://github.com/pmall-neu/rsgm" }
 rand_chacha = "0.3.1"
 getrandom = { version = "0.2", features = ["js"] } # req for wasm
 wasm-bindgen = "0.2.84"
+serde-wasm-bindgen = "0.4"
 
 
 [lib]


### PR DESCRIPTION
This PR primarily adds choice on how a user can generate a VTree. For now, we support right/left-linear and even splits (with the number as an extra parameter).

Right now, `wasm_bindgen` only supports C-like enums, instead of Rust's variant-like approach - so, I need to do some serialization to make this work.

For the future:

1. more VTree generation methods
2. better error message when `even_split` fails

I use these changes in https://github.com/mattxwang/indecision/commit/cacac51ed0c6f8b7784cb82a84b3162059831de1