### PR TITLE
Resolve many open `TODO`s

### DIFF
--- a/bin/bayesian_network_compiler.rs
+++ b/bin/bayesian_network_compiler.rs
@@ -128,7 +128,6 @@ struct Args {
 }
 
 /// construct a CNF for the two TERMS (i.e., conjunctions of literals) t1 => t2
-#[allow(clippy::ptr_arg)]
 fn implies(t1: &Vec<Literal>, t2: &Vec<Literal>) -> Vec<Vec<Literal>> {
     let mut r: Vec<Vec<Literal>> = Vec::new();
     // negate the lhs

--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -55,7 +55,6 @@ fn run_canonicalizer_experiment(c: Cnf, vtree: VTree) {
 
     let start = Instant::now();
 
-    // TODO: make the prime a CLI arg / iterable?
     // 18,446,744,073,709,551,616 - 25
     // let mut sem_mgr = SddManager::<SemanticCanonicalizer<18_446_744_073_709_551_591>>::new(vtree);
     // let mut sem_mgr = SddManager::<SemanticCanonicalizer<100000049>>::new(vtree);

--- a/src/backing_store/bump_table.rs
+++ b/src/backing_store/bump_table.rs
@@ -40,7 +40,6 @@ impl<T: Clone> HashTableElement<T> {
         HashTableElement { ptr, hash, psl }
     }
 
-    #[allow(clippy::cmp_null)] // TODO: fix. unsure why the suggestion (using is_null) doesn't work
     pub fn is_occupied(&self) -> bool {
         self.ptr != std::ptr::null_mut::<T>()
     }
@@ -111,11 +110,6 @@ where
     /// check if item at index `pos` is occupied
     fn is_occupied(&self, pos: usize) -> bool {
         self.tbl[pos].is_occupied()
-    }
-
-    #[allow(dead_code)]
-    fn get_pos(&self, pos: usize) -> *mut T {
-        self.tbl[pos].ptr
     }
 
     /// check the distance the element at index `pos` is from its desired location

--- a/src/builder/bdd_plan.rs
+++ b/src/builder/bdd_plan.rs
@@ -16,7 +16,6 @@ pub enum BddPlan {
 }
 
 impl BddPlan {
-    #[allow(clippy::should_implement_trait)] // TODO: this should probably be renamed not compl?
     pub fn not(p: BddPlan) -> Self {
         Self::Not(Box::new(p))
     }

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -196,7 +196,6 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
                 return Some(node[0].sub());
             }
 
-            // TODO: Why is this only included after compression?
             if self.is_false(node[0].sub()) {
                 return Some(SddPtr::false_ptr());
             }
@@ -601,7 +600,6 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
     fn print_sdd_internal(&self, ptr: SddPtr) -> String {
         self.canonicalizer.on_sdd_print_dump_state(ptr);
         use pretty::*;
-        // TODO: this lifetime might be wrong
         fn helper(ptr: SddPtr) -> Doc<'static, BoxDoc<'static>> {
             if ptr.is_true() {
                 return Doc::from("T");
@@ -1134,7 +1132,5 @@ fn prob_equiv_sdd_demorgan() {
     let sh1 = res.semantic_hash(man.get_vtree_manager(), &map);
     let sh2 = expected.semantic_hash(man.get_vtree_manager(), &map);
 
-    // TODO: need to express this as pointer eq, not semantic eq
-    // assert!(res != expected);
     assert!(sh1 == sh2, "Not eq:\nGot: {:?}\nExpected: {:?}", sh1, sh2);
 }

--- a/src/repr/bdd.rs
+++ b/src/repr/bdd.rs
@@ -174,7 +174,6 @@ impl BddPtr {
     ///
     /// Panics if not a node pointer
     #[inline]
-    #[allow(clippy::mut_from_ref)]
     pub fn mut_node_ref(&self) -> &mut BddNode {
         unsafe {
             match &self {
@@ -517,8 +516,7 @@ impl BddPtr {
 
                 let mut true_model = cur_assgn.clone();
                 true_model.set(*x, true);
-                #[allow(clippy::redundant_clone)]
-                // TODO: remove this, it seems like it's a reasonable lint
+
                 let mut false_model = cur_assgn.clone();
                 false_model.set(*x, false);
 
@@ -740,8 +738,6 @@ impl DDNNFPtr for BddPtr {
         }
     }
 
-    // TODO: we should be able to remove this; e.g. replace v.clone() with *v
-    #[allow(clippy::clone_on_copy)]
     fn fold<T: Clone + Copy + Debug, F: Fn(DDNNF<T>) -> T>(&self, _o: &VarOrder, f: F) -> T {
         debug_assert!(self.is_scratch_cleared());
         fn bottomup_pass_h<T: Clone + Copy + Debug, F: Fn(DDNNF<T>) -> T>(

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -331,7 +331,6 @@ impl SddPtr {
     /// Get a mutable reference to the node that &self points to
     ///
     /// Panics if not a bdd pointer
-    #[allow(clippy::mut_from_ref)]
     pub fn mut_bdd_ref(&self) -> &mut BinarySDD {
         unsafe {
             match &self {
@@ -422,7 +421,6 @@ impl SddPtr {
     /// Get a mutable reference to the node that &self points to
     ///
     /// Panics if not a node pointer
-    #[allow(clippy::mut_from_ref)]
     pub fn node_ref_mut(&self) -> &mut SddOr {
         unsafe {
             match &self {
@@ -505,7 +503,6 @@ impl SddPtr {
             }
             ComplBDD(_) => self.neg().is_trimmed(),
             Reg(_) | Compl(_) => {
-                // TODO(mattxwang): significantly optimize this
                 // this next part is an O(n^2) (i.e., pairwise) comparison of each SDD
                 // and an arbitrary prime. we are looking for untrimmed decomposition pairs of the form (a, T) and (~a, F)
                 let mut visited_primes: HashSet<SddPtr> = HashSet::new();
@@ -542,8 +539,6 @@ type DDNNFCache<T> = (Option<T>, Option<T>);
 impl DDNNFPtr for SddPtr {
     type Order = VTreeManager;
 
-    // TODO: we should be able to remove this; e.g. replace v.clone() with *v
-    #[allow(clippy::clone_on_copy)]
     fn fold<T: Clone + Copy + std::fmt::Debug, F: Fn(super::ddnnf::DDNNF<T>) -> T>(
         &self,
         _v: &VTreeManager,

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -210,7 +210,6 @@ pub struct VTreeManager {
     bfs_to_dfs: Vec<usize>,
     /// maps an Sdd VarLabel into its vtree index in the depth-first order
     vtree_idx: Vec<usize>,
-    #[allow(clippy::vec_box)] // TODO: fix this, but requires some refactoring
     index_lookup: Vec<Box<VTree>>,
     lca: LeastCommonAncestor,
 }

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -67,7 +67,6 @@ impl<T: Semiring + std::ops::Mul<Output = T> + std::ops::Add<Output = T>> WmcPar
 
     // gives you the weight of True and False literals for a given VarLabel
     pub fn get_var_weight(&self, label: VarLabel) -> &(T, T) {
-        // TODO(matt): write a better error message - attempting to get label
         return (self.var_to_val[label.value_usize()]).as_ref().unwrap();
     }
 }

--- a/src/sample/random.rs
+++ b/src/sample/random.rs
@@ -120,24 +120,23 @@ impl<T> Rand for Random<T> {
     }
 }
 
-// TODO this test is broken due to equality checking between floats
-// #[test]
-// fn test_random() {
-//     let b1 = Random::bool(false, Probability::new(0.4), |b| {
-//         Random::uniform_int(false, 0, 4, |x| if b { 0 } else { x })
-//     });
-//     let f = Random::flatten(b1);
-//     assert_eq!(
-//         f.val,
-//         vec![
-//             (0, Probability::new(0.1)),
-//             (0, Probability::new(0.1)),
-//             (0, Probability::new(0.1)),
-//             (0, Probability::new(0.1)),
-//             (0, Probability::new(0.15)),
-//             (1, Probability::new(0.15)),
-//             (2, Probability::new(0.15)),
-//             (3, Probability::new(0.15))
-//         ]
-//     );
-// }
+#[test]
+fn test_random() {
+    let b1 = Random::bool(false, Probability::new(0.4), |b| {
+        Random::uniform_int(false, 0, 4, |x| if b { 0 } else { x })
+    });
+    let f = Random::<usize>::flatten(b1);
+    assert_eq!(
+        f.val,
+        vec![
+            (0, Probability::new(0.1)),
+            (0, Probability::new(0.1)),
+            (0, Probability::new(0.1)),
+            (0, Probability::new(0.1)),
+            (0, Probability::new(0.15)),
+            (1, Probability::new(0.15)),
+            (2, Probability::new(0.15)),
+            (3, Probability::new(0.15))
+        ]
+    );
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -43,7 +43,6 @@ pub fn zero_vec<T>(sz: usize) -> Vec<T> {
 }
 
 /// custom allocation of a non-initialized vector
-#[allow(clippy::uninit_vec)] // intentionally unsafe code
 pub fn malloc_vec<T>(sz: usize) -> Vec<T> {
     let mut v: Vec<T> = Vec::with_capacity(sz);
     unsafe {


### PR DESCRIPTION
Mostly just `#allow`s for clippy that are no longer relevant (confused *why* they aren't tripping up anymore?).

The test that is supposedly broken ... still works?