### PR TITLE
Add apply cache hit % and min-fill `DTree` heuristic

### DIFF
--- a/bin/dump_models.rs
+++ b/bin/dump_models.rs
@@ -56,7 +56,7 @@ fn main() {
 
     let cnf = Cnf::from_file(cnf_input);
 
-    let range: Vec<usize> = (0..cnf.num_vars() + 1).collect();
+    let range: Vec<usize> = (0..cnf.num_vars()).collect();
     let binding = range
         .iter()
         .map(|i| VarLabel::new(*i as u64))

--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -16,19 +16,23 @@ use std::time::Instant;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// An input CNF
+    /// input CNF in DIMACS form
     #[clap(short, long, value_parser)]
     file: String,
 
-    /// use dtree heuristic
+    /// use dtree heuristic (min fill)
     #[clap(short, long, value_parser, default_value_t = false)]
     dtree: bool,
 
+    /// use dtree heuristic (linear order)
+    #[clap(long, value_parser, default_value_t = false)]
+    dtree_linear: bool,
+
     /// use left linear vtree
-    #[clap(short, long, value_parser, default_value_t = false)]
+    #[clap(long, value_parser, default_value_t = false)]
     left_linear: bool,
 
-    /// use even split
+    /// use even split; specify number of splits until right-linear
     #[clap(short, long, value_parser, default_value_t = 0)]
     even_split: u8,
 }
@@ -122,6 +126,9 @@ fn main() {
     } else if args.even_split > 0 {
         VTree::even_split(vars, args.even_split.into())
     } else if args.dtree {
+        let dtree = DTree::from_cnf(&cnf, &cnf.min_fill_order());
+        VTree::from_dtree(&dtree).unwrap()
+    } else if args.dtree_linear {
         let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
         VTree::from_dtree(&dtree).unwrap()
     } else {

--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -110,7 +110,7 @@ fn main() {
         }
     );
 
-    let range: Vec<usize> = (0..cnf.num_vars() + 1).collect();
+    let range: Vec<usize> = (0..cnf.num_vars()).collect();
     let binding = range
         .iter()
         .map(|i| VarLabel::new(*i as u64))

--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -44,11 +44,12 @@ fn run_canonicalizer_experiment(c: Cnf, vtree: VTree) {
 
     let stats = compr_mgr.get_stats();
     println!(
-        "c: {:05} nodes | {:06} uniq | {:07} rec | {} g/i | {}/{} compr/and",
+        "c: {:05} nodes | {:06} uniq | {:07} rec | {} g/i | {:.3}% app cache | {}/{} compr/and",
         compr_cnf.num_nodes(),
         compr_mgr.canonicalizer().bdd_num_uniq() + compr_mgr.canonicalizer().sdd_num_uniq(),
         stats.num_rec,
         stats.num_get_or_insert,
+        stats.num_app_cache_hits as f32 / stats.num_rec as f32 * 100.0,
         stats.num_compr,
         stats.num_compr_and,
     );
@@ -66,11 +67,12 @@ fn run_canonicalizer_experiment(c: Cnf, vtree: VTree) {
 
     let stats = sem_mgr.get_stats();
     println!(
-        "s: {:05} nodes | {:06} uniq | {:07} rec | {} g/i",
+        "s: {:05} nodes | {:06} uniq | {:07} rec | {} g/i | {:.3}% app cache",
         sem_cnf.num_nodes(),
         sem_mgr.canonicalizer().bdd_num_uniq() + sem_mgr.canonicalizer().sdd_num_uniq(),
         stats.num_rec,
         stats.num_get_or_insert,
+        stats.num_app_cache_hits as f32 / stats.num_rec as f32 * 100.0,
     );
 
     println!(" ");

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -25,6 +25,8 @@ pub struct SddStats {
     pub num_compr_and: usize,
     /// total number of gets/inserts generated in compress
     pub num_get_or_insert: usize,
+    /// app cache hits
+    pub num_app_cache_hits: usize,
 }
 
 impl SddStats {
@@ -34,6 +36,7 @@ impl SddStats {
             num_compr: 0,
             num_compr_and: 0,
             num_get_or_insert: 0,
+            num_app_cache_hits: 0,
         }
     }
 }
@@ -456,6 +459,7 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
 
         // check if we have this application cached
         if let Some(x) = self.canonicalizer.app_cache().get(SddAnd::new(a, b)) {
+            self.stats.num_app_cache_hits += 1;
             return x;
         }
 

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -17,8 +17,8 @@ pub fn create_semantic_hash_map<const P: u128>(num_vars: usize) -> WmcParams<Fin
 
     // seed the RNG deterministically for reproducible weights across
     // different calls to `create_semantic_hash_map`
-    let mut rng = ChaCha8Rng::seed_from_u64(101249);
-    // let mut rng = ChaCha8Rng::from_entropy();
+    // let mut rng = ChaCha8Rng::seed_from_u64(101249);
+    let mut rng = ChaCha8Rng::from_entropy();
 
     let value_range: Vec<(FiniteField<P>, FiniteField<P>)> = (0..vars.len() as u128)
         .map(|_| {

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -13,7 +13,8 @@ pub enum VTreeType {
     LeftLinear,
     RightLinear,
     EvenSplit(usize),
-    FromDTree,
+    FromDTreeLinear,
+    FromDTreeMinFill,
 }
 
 // used in: https://github.com/mattxwang/indecision
@@ -73,8 +74,12 @@ fn build_vtree(cnf: &Cnf, vtree_type: VTreeType) -> VTree {
         VTreeType::LeftLinear => VTree::left_linear(vars),
         VTreeType::RightLinear => VTree::right_linear(vars),
         VTreeType::EvenSplit(num) => VTree::even_split(vars, num),
-        VTreeType::FromDTree => {
+        VTreeType::FromDTreeLinear => {
             let dtree = DTree::from_cnf(&cnf, &VarOrder::linear_order(cnf.num_vars()));
+            VTree::from_dtree(&dtree).unwrap()
+        }
+        VTreeType::FromDTreeMinFill => {
+            let dtree = DTree::from_cnf(&cnf, &cnf.min_fill_order());
             VTree::from_dtree(&dtree).unwrap()
         }
     }


### PR DESCRIPTION
This PR:

- uses the min-fill DTree heuristic; changes wasm build to have distinct types
- adds apply cache hit % to semantic hash experiment results
- fixes some other off-by-one errors
- very minor QoL changes to CLI

## apply cache hit % observations

Interesting cases:

This always wins in both cache hits and rec calls

```
cnfgen randkcnf 5 10 60 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- --file cnf/rand.cnf -e 1
```

But, bumping to `-e 2` makes us lose in hit %, though still win in rec calls

```
cnfgen randkcnf 5 10 60 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- --file cnf/rand.cnf -e 2
```