### PR TITLE
Cache semantic hashes on `sdd_eq`

### DIFF
--- a/src/backing_store/bump_table.rs
+++ b/src/backing_store/bump_table.rs
@@ -89,6 +89,8 @@ where
     cap: usize,
     /// the length of `tbl`
     len: usize,
+    /// # cache hits
+    hits: usize,
 }
 
 impl<T: Clone> BackedRobinhoodTable<T>
@@ -104,6 +106,7 @@ where
             alloc: Bump::new(),
             cap: DEFAULT_SIZE,
             len: 0,
+            hits: 0,
         }
     }
 
@@ -145,6 +148,10 @@ where
     pub fn num_nodes(&self) -> usize {
         self.len
     }
+
+    pub fn hits(&self) -> usize {
+        self.hits
+    }
 }
 
 impl<T: Eq + PartialEq + Hash + Clone, H: UniqueTableHasher<T>> UniqueTable<T, H>
@@ -171,6 +178,7 @@ impl<T: Eq + PartialEq + Hash + Clone, H: UniqueTableHasher<T>> UniqueTable<T, H
                 if elem_hash == cur_itm.hash {
                     let found: &T = unsafe { &*cur_itm.ptr };
                     if *found == elem {
+                        self.hits += 1;
                         return cur_itm.ptr;
                     }
                 }

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -660,15 +660,15 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         self.canonicalizer.on_sdd_print_dump_state(ptr)
     }
 
-    pub fn sdd_eq(&self, a: SddPtr, b: SddPtr) -> bool {
+    pub fn sdd_eq(&mut self, a: SddPtr, b: SddPtr) -> bool {
         self.canonicalizer.sdd_eq(a, b)
     }
 
-    pub fn is_true(&self, a: SddPtr) -> bool {
+    pub fn is_true(&mut self, a: SddPtr) -> bool {
         self.sdd_eq(a, SddPtr::PtrTrue)
     }
 
-    pub fn is_false(&self, a: SddPtr) -> bool {
+    pub fn is_false(&mut self, a: SddPtr) -> bool {
         self.sdd_eq(a, SddPtr::PtrFalse)
     }
 

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -179,6 +179,7 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
             return SddPtr::var(bdd.label(), true);
         }
 
+        self.stats.num_get_or_insert += 1;
         // uniqify BDD
         if bdd.high().is_neg() || self.is_false(bdd.high()) || bdd.high().is_neg_var() {
             let neg_bdd =

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -1114,7 +1114,7 @@ fn prob_equiv_sdd_demorgan() {
     use crate::repr::bdd::WmcParams;
     use crate::util::semiring::FiniteField;
 
-    let mut man = SddManager::<crate::builder::canonicalize::SemanticCanonicalizer<1223>>::new(
+    let mut man = SddManager::<crate::builder::canonicalize::SemanticCanonicalizer<100000049>>::new(
         VTree::even_split(
             &[
                 VarLabel::new(0),
@@ -1132,7 +1132,7 @@ fn prob_equiv_sdd_demorgan() {
     let res = man.or(x, y).neg();
     let expected = man.and(x.neg(), y.neg());
 
-    let map: WmcParams<FiniteField<1223>> = create_semantic_hash_map(man.num_vars());
+    let map: WmcParams<FiniteField<100000049>> = create_semantic_hash_map(man.num_vars());
 
     let sh1 = res.semantic_hash(man.get_vtree_manager(), &map);
     let sh2 = expected.semantic_hash(man.get_vtree_manager(), &map);

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -13,12 +13,14 @@ pub fn create_semantic_hash_map<const P: u128>(num_vars: usize) -> WmcParams<Fin
     let vars: Vec<VarLabel> = (0..num_vars).map(|x| VarLabel::new_usize(x)).collect();
 
     // theoretical guarantee from paper; need to verify more!
-    assert!((2 * vars.len() as u128) < P);
+    // in "theory", this should be a 0.1% fail rate in one-shot for a BDD.
+    // not sure how to extend to SDDs (and this does not happen in practice)
+    assert!(((vars.len() * 1000) as u128) < P);
 
     // seed the RNG deterministically for reproducible weights across
     // different calls to `create_semantic_hash_map`
-    // let mut rng = ChaCha8Rng::seed_from_u64(101249);
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::seed_from_u64(101249);
+    // let mut rng = ChaCha8Rng::from_entropy();
 
     let value_range: Vec<(FiniteField<P>, FiniteField<P>)> = (0..vars.len() as u128)
         .map(|_| {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -702,7 +702,7 @@ mod test_sdd_manager {
             let mut mgr2 = super::SddManager::<SemanticCanonicalizer<{ crate::BIG_PRIME }>>::new(vtree);
             let c2 = mgr2.from_cnf(&c);
 
-            let map : WmcParams<FiniteField<1123>> = create_semantic_hash_map(mgr1.num_vars());
+            let map : WmcParams<FiniteField<100000049>> = create_semantic_hash_map(mgr1.num_vars());
 
             let h1 = c1.semantic_hash(mgr1.get_vtree_manager(), &map);
             let h2 = c2.semantic_hash(mgr2.get_vtree_manager(), &map);
@@ -721,7 +721,7 @@ mod test_sdd_manager {
             let uncompr_cnf = uncompr_mgr.from_cnf(&c);
 
 
-            let map : WmcParams<FiniteField<4391>> = create_semantic_hash_map(compr_mgr.num_vars());
+            let map : WmcParams<FiniteField<100000049>> = create_semantic_hash_map(compr_mgr.num_vars());
 
             let compr_h = compr_cnf.semantic_hash(compr_mgr.get_vtree_manager(), &map);
             let uncompr_h = uncompr_cnf.semantic_hash(uncompr_mgr.get_vtree_manager(), &map);


### PR DESCRIPTION
Going to flesh this out more later, my dishwasher exploded in suds 😠 

Overall idea: conservative cache strategy that doesn't change most of the codebase (e.g. not modifying the underlying pointer/raw data structure). Con is that we can't cache everything (ex this doesn't go "into" `fold`). Perhaps can eventually refactor to be at the `DNNF` level.

This PR also:

- logs cache hit % in the backedrobinhoodtable
- fixes some minor log formatting things

---


More SDDs are now feasible. For example, consider:

```
cnfgen randkcnf 3 25 75 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- --file cnf/rand.cnf -d
```

On average, we get huge app cache hit rates. Here's one "golden" example:

```
cnfgen randkcnf 3 25 75 > cnf/rand.cnf && cargo run --bin semantic_hash_experiment --release -- --file cnf/rand.cnf -d
num vars: 25
vtree: from_dtree
vtree num vars: 25
 
c: 00063 nodes | 013328 bdd / 005066 sdd uniq | 0422075 rec | 10279 g/i | 37.524% app cache | 57542/64307 compr/and
s: 00512 nodes | 003225 bdd / 003929 sdd uniq | 0711514 rec | 12533 g/i | 72.455% app cache
 
c time: 46.46675ms
s time: 607.574041ms
 
h: 305108354
sdd eq cache hits: 11022109
```


