### PR TITLE
Semantic hash-focused codebase cleanup

### DIFF
--- a/bin/one_shot_benchmark.rs
+++ b/bin/one_shot_benchmark.rs
@@ -113,11 +113,8 @@ fn compile_sdd_dtree(str: String, _args: &Args) -> BenchResult {
         assert!(r.is_ok(), "Error writing file");
     }
 
-    // println!("num redundant: {}", man.num_logically_redundant());
-    // println!("num nodes: {}", man.node_iter().count());
-
     BenchResult {
-        num_recursive: man.get_stats().num_rec,
+        num_recursive: man.stats().num_rec,
         size: _sdd.count_nodes(),
     }
 }
@@ -147,7 +144,7 @@ fn compile_sdd_rightlinear(str: String, _args: &Args) -> BenchResult {
     }
 
     BenchResult {
-        num_recursive: man.get_stats().num_rec,
+        num_recursive: man.stats().num_rec,
         size: _sdd.count_nodes(),
     }
 }

--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -71,7 +71,7 @@ impl BenchStats {
         sdd: &SddPtr,
         mgr: &SddManager<T>,
     ) -> BenchStats {
-        let stats = mgr.get_stats();
+        let stats = mgr.stats();
         BenchStats {
             label,
             time,

--- a/src/builder/cache/sdd_apply_cache.rs
+++ b/src/builder/cache/sdd_apply_cache.rs
@@ -66,6 +66,7 @@ impl<const P: u128> SddApply for SddApplySemantic<P> {
             _ => self.table.get(&h.value()).copied(),
         }
     }
+    /// assumption: we've already checked if element is in cache
     fn insert(&mut self, and: SddAnd, ptr: SddPtr) {
         let h = and.semantic_hash(&self.vtree, &self.map);
         if h.value() > 1 {

--- a/src/builder/canonicalize.rs
+++ b/src/builder/canonicalize.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 
-use rustc_hash::{FxHashMap, FxHasher};
+use rustc_hash::FxHasher;
 
 use super::bdd_builder::DDNNFPtr;
 use super::cache::sdd_apply_cache::{SddApply, SddApplyCompression, SddApplySemantic};
@@ -21,14 +21,12 @@ pub trait SddCanonicalizationScheme {
     fn should_compress(&self) -> bool;
 
     /// this is mutable because we may update an internal cache
-    fn sdd_eq(&mut self, s1: SddPtr, s2: SddPtr) -> bool;
+    fn sdd_eq(&mut self, a: SddPtr, b: SddPtr) -> bool;
     fn app_cache(&mut self) -> &mut Self::ApplyCacheMethod;
 
     // BackedRobinhoodTable-related methods
     fn bdd_tbl(&self) -> &BackedRobinhoodTable<BinarySDD>;
     fn sdd_tbl(&self) -> &BackedRobinhoodTable<SddOr>;
-    fn bdd_hasher(&self) -> &Self::BddHasher;
-    fn sdd_hasher(&self) -> &Self::SddOrHasher;
     fn bdd_get_or_insert(&mut self, item: BinarySDD) -> *mut BinarySDD;
     fn sdd_get_or_insert(&mut self, item: SddOr) -> *mut SddOr;
 
@@ -59,8 +57,8 @@ impl SddCanonicalizationScheme for CompressionCanonicalizer {
         }
     }
 
-    fn sdd_eq(&mut self, s1: SddPtr, s2: SddPtr) -> bool {
-        s1 == s2
+    fn sdd_eq(&mut self, a: SddPtr, b: SddPtr) -> bool {
+        a == b
     }
 
     fn set_compress(&mut self, b: bool) {
@@ -81,14 +79,6 @@ impl SddCanonicalizationScheme for CompressionCanonicalizer {
 
     fn sdd_tbl(&self) -> &BackedRobinhoodTable<SddOr> {
         &self.sdd_tbl
-    }
-
-    fn bdd_hasher(&self) -> &Self::BddHasher {
-        &self.hasher
-    }
-
-    fn sdd_hasher(&self) -> &Self::SddOrHasher {
-        &self.hasher
     }
 
     fn bdd_get_or_insert(&mut self, item: BinarySDD) -> *mut BinarySDD {
@@ -120,30 +110,29 @@ impl<const P: u128> UniqueTableHasher<BinarySDD> for SemanticUniqueTableHasher<P
 
         let (low_w, high_w) = self.map.get_var_weight(elem.label());
 
-        // TODO(matt): investigate if this works properly!
-        FiniteField::<P>::new(
-            elem.low().cached_semantic_hash(&self.vtree, &self.map).value() * low_w.value()
-            // (P - elem.low().semantic_hash(&self.vtree, &self.map).value() + 1) * low_w.value()
-                + elem.high().cached_semantic_hash(&self.vtree, &self.map).value() * high_w.value(),
-        )
-        .value()
+        (elem
+            .low()
+            .cached_semantic_hash(&self.vtree, &self.map)
+            .value()
+            * low_w.value()
+            + elem
+                .high()
+                .cached_semantic_hash(&self.vtree, &self.map)
+                .value()
+                * high_w.value())
         .hash(&mut hasher);
         hasher.finish()
     }
 }
 
 impl<const P: u128> UniqueTableHasher<SddOr> for SemanticUniqueTableHasher<P> {
-    // TODO(matt): we should be able to de-duplicate this with fold/wmc
     fn u64hash(&self, elem: &SddOr) -> u64 {
         let mut hasher = FxHasher::default();
-        FiniteField::<P>::new(
-            elem.nodes
-                .iter()
-                .map(|and| and.semantic_hash(&self.vtree, &self.map).value())
-                .fold(0, |accum, elem| accum + elem),
-        )
-        .value()
-        .hash(&mut hasher);
+        elem.nodes
+            .iter()
+            .map(|and| and.semantic_hash(&self.vtree, &self.map).value())
+            .fold(0, |accum, elem| accum + elem)
+            .hash(&mut hasher);
         hasher.finish()
     }
 }
@@ -156,22 +145,6 @@ pub struct SemanticCanonicalizer<const P: u128> {
     bdd_tbl: BackedRobinhoodTable<BinarySDD>,
     sdd_tbl: BackedRobinhoodTable<SddOr>,
     hasher: SemanticUniqueTableHasher<P>,
-    cached_hashes: FxHashMap<SddPtr, FiniteField<P>>,
-    cache_hits: usize,
-}
-
-impl<const P: u128> SemanticCanonicalizer<P> {
-    fn get_or_insert_semantic_hash(&mut self, s: SddPtr) -> FiniteField<P> {
-        if let Some(cached) = self.cached_hashes.get(&s) {
-            // println!("cache hit");
-            self.cache_hits += 1;
-            *cached
-        } else {
-            let hash = s.cached_semantic_hash(&self.vtree, &self.map);
-            self.cached_hashes.insert(s, hash);
-            hash
-        }
-    }
 }
 
 impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
@@ -190,14 +163,12 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
             sdd_tbl: BackedRobinhoodTable::new(),
             hasher: SemanticUniqueTableHasher::new(vtree.clone(), map.clone()),
             map,
-            cached_hashes: FxHashMap::default(),
-            cache_hits: 0,
         }
     }
 
-    fn sdd_eq(&mut self, s1: SddPtr, s2: SddPtr) -> bool {
-        let h1 = self.get_or_insert_semantic_hash(s1);
-        let h2 = self.get_or_insert_semantic_hash(s2);
+    fn sdd_eq(&mut self, a: SddPtr, b: SddPtr) -> bool {
+        let h1 = a.cached_semantic_hash(&self.vtree, &self.map);
+        let h2 = b.cached_semantic_hash(&self.vtree, &self.map);
         h1 == h2
     }
 
@@ -221,14 +192,6 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
         &self.sdd_tbl
     }
 
-    fn bdd_hasher(&self) -> &Self::BddHasher {
-        &self.hasher
-    }
-
-    fn sdd_hasher(&self) -> &Self::SddOrHasher {
-        &self.hasher
-    }
-
     fn bdd_get_or_insert(&mut self, item: BinarySDD) -> *mut BinarySDD {
         self.bdd_tbl.get_or_insert(item, &self.hasher)
     }
@@ -239,6 +202,5 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
 
     fn on_sdd_print_dump_state(&self, ptr: SddPtr) {
         println!("h: {}", ptr.semantic_hash(&self.vtree, &self.map));
-        println!("sdd eq cache hits: {}", self.cache_hits)
     }
 }

--- a/src/builder/sdd_builder.rs
+++ b/src/builder/sdd_builder.rs
@@ -9,6 +9,7 @@ use super::cache::ite::Ite;
 use super::cache::sdd_apply_cache::SddApply;
 use super::cache::LruTable;
 use super::canonicalize::*;
+
 use crate::repr::bdd::create_semantic_hash_map;
 use crate::repr::ddnnf::DDNNFPtr;
 use crate::repr::sdd::{BinarySDD, SddAnd, SddOr, SddPtr};
@@ -788,29 +789,18 @@ impl<T: SddCanonicalizationScheme> SddManager<T> {
         // }
     }
 
-    /// get an iterator over all allocated or-nodes
-    fn or_iter(&self) -> impl Iterator<Item = *mut SddOr> + '_ {
-        self.canonicalizer.sdd_tbl().iter()
-    }
-
-    /// get an iterator over all allocated bdd nodes
-    fn bdd_iter(&self) -> impl Iterator<Item = *mut BinarySDD> + '_ {
-        self.canonicalizer.bdd_tbl().iter()
-    }
-
     /// get an iterator over all unique allocated nodes by the manager
     pub fn node_iter(&self) -> impl Iterator<Item = SddPtr> + '_ {
-        let bdditer = self.bdd_iter().map(|x| SddPtr::bdd(x));
-        self.or_iter().map(|x| SddPtr::Reg(x)).chain(bdditer)
+        let bdditer = self.canonicalizer.bdd_tbl().iter().map(|x| SddPtr::bdd(x));
+        self.canonicalizer
+            .sdd_tbl()
+            .iter()
+            .map(|x| SddPtr::Reg(x))
+            .chain(bdditer)
     }
 
-    pub fn get_stats(&self) -> &SddStats {
+    pub fn stats(&self) -> &SddStats {
         &self.stats
-    }
-
-    pub fn print_stats(&self) {
-        println!("***************[ SDD Stats ]***************");
-        println!("\tNumber of recursive calls: {}", self.stats.num_rec);
     }
 
     /// computes the number of logically redundant nodes allocated by the

--- a/src/repr/ddnnf.rs
+++ b/src/repr/ddnnf.rs
@@ -96,7 +96,6 @@ pub trait DDNNFPtr: Clone + Debug + PartialEq + Eq + Hash + Copy {
         order: &Self::Order,
         map: &WmcParams<FiniteField<P>>,
     ) -> FiniteField<P> {
-        // panic!();
         self.wmc(order, map)
     }
 

--- a/src/repr/sdd.rs
+++ b/src/repr/sdd.rs
@@ -145,7 +145,6 @@ impl SddAnd {
     pub fn new(prime: SddPtr, sub: SddPtr) -> SddAnd {
         SddAnd { prime, sub }
     }
-    // TODO(matt): we should be able to de-duplicate this with fold/wmc
     pub fn semantic_hash<const P: u128>(
         &self,
         vtree: &VTreeManager,
@@ -211,54 +210,42 @@ impl SddPtr {
         vtree: &VTreeManager,
         map: &WmcParams<FiniteField<P>>,
     ) -> FiniteField<P> {
-        if self.is_true() {
-            return FiniteField::new(1);
-        }
-        if self.is_false() {
-            return FiniteField::new(0);
-        }
-        if self.is_or() {
-            let r = self.node_ref_mut();
-            if r.semantic_hash.is_some() {
-                let v = FiniteField::new(r.semantic_hash.unwrap());
-                return if self.is_neg() { v.negate() } else { v };
+        match self {
+            PtrTrue => FiniteField::new(1),
+            PtrFalse => FiniteField::new(0),
+            Var(label, polarity) => {
+                let (l_w, h_w) = map.get_var_weight(*label);
+                return if *polarity { *h_w } else { *l_w };
             }
-            // no cached value, compute it
-            let h = self.node_iter().fold(FiniteField::new(0), |acc, i| {
-                acc + i.prime().cached_semantic_hash(vtree, map)
-                    * i.sub().cached_semantic_hash(vtree, map)
-            });
-            self.node_ref_mut().semantic_hash = Some(h.value());
-            if self.is_neg() {
-                return h.negate();
-            } else {
-                return h;
-            };
-        }
-        if self.is_var() {
-            let v = self.get_var();
-            let (h_w, l_w) = map.get_var_weight(v.get_label());
-            if v.get_polarity() {
-                return *h_w;
-            } else {
-                return *l_w;
+            BDD(_) => {
+                if let Some(h) = self.mut_bdd_ref().semantic_hash {
+                    return FiniteField::new(h);
+                }
+
+                // no cached value, compute it
+                let l_h = self.low().cached_semantic_hash(vtree, map);
+                let h_h = self.high().cached_semantic_hash(vtree, map);
+                let (l_w, h_w) = map.get_var_weight(self.topvar());
+
+                let h = (*l_w) * l_h + (*h_w) * h_h;
+                self.mut_bdd_ref().semantic_hash = Some(h.value());
+                h
             }
-        }
-        if self.is_bdd() {
-            let b = self.mut_bdd_ref();
-            if b.semantic_hash.is_some() {
-                let h = FiniteField::new(b.semantic_hash.unwrap());
-                return if self.is_neg() { h.negate() } else { h };
+            Reg(_) => {
+                if let Some(h) = self.node_ref_mut().semantic_hash {
+                    return FiniteField::new(h);
+                }
+
+                // no cached value, compute it
+                let h = self.node_iter().fold(FiniteField::new(0), |acc, i| {
+                    acc + i.prime().cached_semantic_hash(vtree, map)
+                        * i.sub().cached_semantic_hash(vtree, map)
+                });
+
+                self.node_ref_mut().semantic_hash = Some(h.value());
+                h
             }
-            let var = self.topvar();
-            let l_h = self.low_raw().cached_semantic_hash(vtree, map);
-            let h_h = self.high_raw().cached_semantic_hash(vtree, map);
-            let (h_w, l_w) = map.get_var_weight(var);
-            let h = (*l_w) * l_h + (*h_w) * h_h;
-            b.semantic_hash = Some(h.value());
-            return if self.is_neg() { h.negate() } else { h };
-        } else {
-            panic!();
+            ComplBDD(_) | Compl(_) => self.neg().cached_semantic_hash(vtree, map).negate(),
         }
     }
 
@@ -520,22 +507,14 @@ impl SddPtr {
         }
     }
 
-    fn is_canonical_h(&self) -> bool {
-        self.is_compressed() && self.is_trimmed()
-    }
-
     pub fn is_canonical(&self) -> bool {
-        self.is_canonical_h()
+        self.is_compressed() && self.is_trimmed()
     }
 
     // predicate that returns if an SDD is compressed;
     // see https://www.ijcai.org/Proceedings/11/Papers/143.pdf
     // definition 8
     pub fn is_compressed(&self) -> bool {
-        self.is_compressed_h()
-    }
-
-    fn is_compressed_h(&self) -> bool {
         match &self {
             PtrTrue => true,
             PtrFalse => true,
@@ -561,10 +540,6 @@ impl SddPtr {
     }
 
     pub fn is_trimmed(&self) -> bool {
-        self.is_trimmed_h()
-    }
-
-    fn is_trimmed_h(&self) -> bool {
         match &self {
             PtrTrue => true,
             PtrFalse => true,

--- a/src/repr/wmc.rs
+++ b/src/repr/wmc.rs
@@ -65,7 +65,7 @@ impl<T: Semiring + std::ops::Mul<Output = T> + std::ops::Add<Output = T>> WmcPar
         self.var_to_val[n] = Some((low, high));
     }
 
-    // gives you the weight of True and False literals for a given VarLabel
+    // gives you the weight of `(low, high)` literals for a given VarLabel
     pub fn get_var_weight(&self, label: VarLabel) -> &(T, T) {
         return (self.var_to_val[label.value_usize()]).as_ref().unwrap();
     }


### PR DESCRIPTION
This PR does some cleanup based on a debugging pass I did in #83.

This PR:

- removes commented code that's not helpful
- standardizes some naming
- removes caching on `sdd_eq`, since it duplicates work with Steven's cache-on-`Ptr` work (ex `get_or_insert_semantic_hash`)
- removes level of indirection on `or_iter` and `bdd_iter` and some predicates
- removes unused `bdd_hasher`/`sdd_hasher` interfaces to `trait`
- temporarily disables the `BddSemanticUniqueTableHasher`, since the prime can disagree with current tests
- refactors the cached semantic hash to use pattern matching instead of potentially-unsafe guards
- adds quickcheck that reg + compl = 1