### PR TITLE
Check `BinarySdd`/`SddOr` cache for negated hash

### DIFF
--- a/src/builder/canonicalize.rs
+++ b/src/builder/canonicalize.rs
@@ -204,6 +204,7 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
     }
 
     fn bdd_get_or_insert(&mut self, item: BinarySDD) -> SddPtr {
+        // check regular hash
         let semantic_hash = item.semantic_hash(&self.vtree, &self.map);
         let mut hasher = FxHasher::default();
         semantic_hash.value().hash(&mut hasher);
@@ -211,10 +212,22 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
         if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
             return sdd;
         }
+
+        // check negated hash
+        let semantic_hash = semantic_hash.negate();
+        let mut hasher = FxHasher::default();
+        semantic_hash.value().hash(&mut hasher);
+        let hash = hasher.finish();
+        if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
+            return sdd.neg();
+        }
+
+        // insert
         SddPtr::BDD(self.bdd_tbl.get_or_insert(item, &self.hasher))
     }
 
     fn sdd_get_or_insert(&mut self, item: SddOr) -> SddPtr {
+        // check regular hash
         let semantic_hash = item.semantic_hash(&self.vtree, &self.map);
         let mut hasher = FxHasher::default();
         semantic_hash.value().hash(&mut hasher);
@@ -222,6 +235,17 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
         if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
             return sdd;
         }
+
+        // check negated hash
+        let semantic_hash = semantic_hash.negate();
+        let mut hasher = FxHasher::default();
+        semantic_hash.value().hash(&mut hasher);
+        let hash = hasher.finish();
+        if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
+            return sdd.neg();
+        }
+
+        // insert
         SddPtr::or(self.sdd_tbl.get_or_insert(item, &self.hasher))
     }
 

--- a/src/builder/canonicalize.rs
+++ b/src/builder/canonicalize.rs
@@ -157,6 +157,26 @@ impl<const P: u128> SemanticCanonicalizer<P> {
             }
         }
     }
+
+    fn check_cached_hash_and_neg(&mut self, semantic_hash: FiniteField<P>) -> Option<SddPtr> {
+        // check regular hash
+        let mut hasher = FxHasher::default();
+        semantic_hash.value().hash(&mut hasher);
+        let hash = hasher.finish();
+        if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
+            return Some(sdd);
+        }
+
+        // check negated hash
+        let semantic_hash = semantic_hash.negate();
+        let mut hasher = FxHasher::default();
+        semantic_hash.value().hash(&mut hasher);
+        let hash = hasher.finish();
+        if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
+            return Some(sdd.neg());
+        }
+        None
+    }
 }
 impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
     type ApplyCacheMethod = SddApplySemantic<P>;
@@ -204,48 +224,20 @@ impl<const P: u128> SddCanonicalizationScheme for SemanticCanonicalizer<P> {
     }
 
     fn bdd_get_or_insert(&mut self, item: BinarySDD) -> SddPtr {
-        // check regular hash
         let semantic_hash = item.semantic_hash(&self.vtree, &self.map);
-        let mut hasher = FxHasher::default();
-        semantic_hash.value().hash(&mut hasher);
-        let hash = hasher.finish();
-        if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
+        if let Some(sdd) = self.check_cached_hash_and_neg(semantic_hash) {
             return sdd;
         }
 
-        // check negated hash
-        let semantic_hash = semantic_hash.negate();
-        let mut hasher = FxHasher::default();
-        semantic_hash.value().hash(&mut hasher);
-        let hash = hasher.finish();
-        if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
-            return sdd.neg();
-        }
-
-        // insert
         SddPtr::BDD(self.bdd_tbl.get_or_insert(item, &self.hasher))
     }
 
     fn sdd_get_or_insert(&mut self, item: SddOr) -> SddPtr {
-        // check regular hash
         let semantic_hash = item.semantic_hash(&self.vtree, &self.map);
-        let mut hasher = FxHasher::default();
-        semantic_hash.value().hash(&mut hasher);
-        let hash = hasher.finish();
-        if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
+        if let Some(sdd) = self.check_cached_hash_and_neg(semantic_hash) {
             return sdd;
         }
 
-        // check negated hash
-        let semantic_hash = semantic_hash.negate();
-        let mut hasher = FxHasher::default();
-        semantic_hash.value().hash(&mut hasher);
-        let hash = hasher.finish();
-        if let Some(sdd) = self.get_shared_sdd_ptr(semantic_hash, hash) {
-            return sdd.neg();
-        }
-
-        // insert
         SddPtr::or(self.sdd_tbl.get_or_insert(item, &self.hasher))
     }
 


### PR DESCRIPTION
This PR:

- adds a check on `get_by_hash` to also try the negated semantic hash; if it exists, returns a negated pointer
- checks for negated hashes in our canonicity/uniqueness quickcheck test