### PR TITLE
Add `--right-bias` flag for random VTree generation

### DIFF
--- a/bin/semantic_hash_experiment.rs
+++ b/bin/semantic_hash_experiment.rs
@@ -29,6 +29,10 @@ struct Args {
     #[clap(short, long, value_parser, default_value_t = 0)]
     run_random_vtrees: usize,
 
+    /// how right-biased should random vtrees be? 1 is right-linear, 0 is even split
+    #[clap(long, value_parser, default_value_t = 0.75)]
+    right_bias: f64,
+
     /// use dtree heuristic (min fill)
     #[clap(short, long, value_parser, default_value_t = false)]
     dtree: bool,
@@ -134,7 +138,7 @@ fn vtree_rightness(vtree: &VTree) -> f32 {
     (helper(vtree) - 1) as f32 / (vtree.num_vars() - 2) as f32
 }
 
-fn run_random_comparisons(cnf: Cnf, order: &[VarLabel], num: usize) {
+fn run_random_comparisons(cnf: Cnf, order: &[VarLabel], num: usize, bias: f64) {
     println!("---");
 
     let mut avg_nodes_cnf_sem = 0;
@@ -144,7 +148,7 @@ fn run_random_comparisons(cnf: Cnf, order: &[VarLabel], num: usize) {
     let mut avg_rec_compr = 0;
 
     for _ in 0..num {
-        let vtree = VTree::rand_split(order);
+        let vtree = VTree::rand_split(order, bias);
 
         let (compr, sem) = run_compr_sem(&cnf, &vtree);
         println!(
@@ -227,7 +231,11 @@ fn main() {
     println!("num vars: {}", cnf.num_vars());
 
     if args.run_random_vtrees > 0 {
-        run_random_comparisons(cnf, vars, args.run_random_vtrees);
+        println!(
+            "random search (right-bias {}), n={}",
+            args.right_bias, args.run_random_vtrees
+        );
+        run_random_comparisons(cnf, vars, args.run_random_vtrees, args.right_bias);
         return;
     }
 

--- a/src/repr/vtree.rs
+++ b/src/repr/vtree.rs
@@ -170,7 +170,8 @@ impl VTree {
         }
     }
 
-    pub fn rand_split(order: &[VarLabel]) -> VTree {
+    /// rightness_bias 0 is a random even split; rightness
+    pub fn rand_split(order: &[VarLabel], rightness_bias: f64) -> VTree {
         match order.len() {
             0 => panic!("invalid label order passed; expects at least one VarLabel"),
             1 => VTree::new_leaf(order[0]),
@@ -181,11 +182,16 @@ impl VTree {
             len => {
                 // clamps so we're guaranteed at least one item in l_s, r_s
                 let mut rng = ChaCha8Rng::from_entropy();
-                let split_index = rng.gen_range(1..len);
+
+                // let mut split_index = rng.gen_range(1..(len/2+1));
+                let weighted_index =
+                    (rng.gen_range(0..len - 1) as f64 * (1.0 - rightness_bias)) as usize;
+                let split_index = weighted_index + 1;
+
                 let (l_s, r_s) = order.split_at(split_index);
                 VTree::new_node(
-                    Box::new(Self::rand_split(l_s)),
-                    Box::new(Self::rand_split(r_s)),
+                    Box::new(Self::rand_split(l_s, rightness_bias)),
+                    Box::new(Self::rand_split(r_s, rightness_bias)),
                 )
             }
         }


### PR DESCRIPTION
Example usage:

```
$ cargo run --bin semantic_hash_experiment --release -- --file cnf/rand.cnf -r 100 --right-bias 0.8
... omittted
---
total c/s (n=100): 2.34x nodes | 0.98x rec

```